### PR TITLE
Improve Claude marketplace structure, docs, and validation automation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,54 +1,46 @@
 {
   "name": "Claude-m Microsoft Marketplace",
-  "description": "A Claude Code plugin marketplace for Microsoft 365, Teams, Excel, Outlook, Azure, and SharePoint integrations via MCP",
-  "version": "1.0.0",
-  "author": "Claude-m",
-  "homepage": "https://github.com/markus41/Claude-m",
+  "description": "Focused Claude marketplace for Microsoft workflow plugins maintained in this repository.",
   "plugins": [
     {
       "name": "Microsoft Teams MCP",
       "source": "https://github.com/markus41/Claude-m",
+      "description": "Send messages, create meetings, and manage Teams channels via MCP.",
       "category": "productivity",
-      "tags": ["microsoft", "teams", "collaboration", "meetings", "mcp"],
-      "description": "Send messages, create meetings, and manage Microsoft Teams channels via MCP server",
-      "version": "1.0.0",
-      "strict": false
+      "tags": ["microsoft", "teams", "collaboration"],
+      "strict": true
     },
     {
       "name": "Microsoft Excel MCP",
       "source": "https://github.com/markus41/Claude-m",
+      "description": "Read and update workbooks, worksheets, ranges, and tables via MCP.",
       "category": "productivity",
-      "tags": ["microsoft", "excel", "spreadsheet", "data", "mcp"],
-      "description": "Read and write Excel workbooks, manage worksheets, and work with tables via MCP server",
-      "version": "1.0.0",
-      "strict": false
+      "tags": ["microsoft", "excel", "data"],
+      "strict": true
     },
     {
       "name": "Microsoft Outlook MCP",
       "source": "https://github.com/markus41/Claude-m",
+      "description": "Send email and manage inbox/calendar tasks via MCP.",
       "category": "productivity",
-      "tags": ["microsoft", "outlook", "email", "calendar", "mcp"],
-      "description": "Send emails, list inbox messages, and manage calendar events via MCP server",
-      "version": "1.0.0",
-      "strict": false
+      "tags": ["microsoft", "outlook", "email"],
+      "strict": true
     },
     {
       "name": "Microsoft Azure MCP",
       "source": "https://github.com/markus41/Claude-m",
+      "description": "Inspect subscriptions, resource groups, and resources via MCP.",
       "category": "cloud",
-      "tags": ["microsoft", "azure", "cloud", "infrastructure", "mcp"],
-      "description": "Manage Azure resources, subscriptions, and resource groups via MCP server",
-      "version": "1.0.0",
-      "strict": false
+      "tags": ["microsoft", "azure", "infrastructure"],
+      "strict": true
     },
     {
       "name": "Microsoft SharePoint MCP",
       "source": "https://github.com/markus41/Claude-m",
+      "description": "Browse and transfer SharePoint files through MCP tools.",
       "category": "productivity",
-      "tags": ["microsoft", "sharepoint", "files", "documents", "mcp"],
-      "description": "List, upload, and download files from SharePoint sites via MCP server",
-      "version": "1.0.0",
-      "strict": false
+      "tags": ["microsoft", "sharepoint", "documents"],
+      "strict": true
     }
   ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - work
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Type-check
+        run: npm run lint
+
+      - name: Unit tests
+        run: npm test
+
+      - name: Marketplace schema validation
+        run: npm run validate:marketplace
+
+      - name: Plugin manifest validation
+        run: npm run validate:plugins

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,15 @@
+# CLAUDE.md
+
+## Usage
+- Add this marketplace: `/plugin marketplace add markus41/Claude-m`
+- Validate locally: `claude plugin validate .` (CLI) or `/plugin validate .` (inside Claude)
+- Install from this marketplace: `/plugin install "Microsoft Azure MCP@Claude-m Microsoft Marketplace"`
+
+## Prompt examples
+- "Use Microsoft Azure MCP to list my resource groups in subscription `<id>` and flag idle resources."
+- "Use Microsoft Teams MCP to draft and send a standup update to channel `<channel-id>`."
+- "Use Microsoft Outlook MCP to summarize unread inbox messages and schedule a follow-up event."
+
+## Opinionated flows
+1. **Microsoft integration bootstrap**: install Teams + Outlook + SharePoint plugins, then run a workspace health check prompt for communication, files, and scheduling.
+2. **Azure review flow**: install Azure plugin, list subscriptions/resource groups/resources, then ask Claude to identify misconfigurations and cost hotspots.

--- a/README.md
+++ b/README.md
@@ -1,245 +1,82 @@
 # Claude-m
 
-> **A Claude plugin marketplace that extends Claude's ability to work with Microsoft products via MCP.**
+A focused Claude plugin marketplace for Microsoft workflows (Azure, Teams, Outlook, Excel, SharePoint) backed by one MCP server.
 
-Claude-m is an [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server that gives Claude native access to Microsoft 365, Microsoft Teams, Microsoft Azure, and SharePoint — all through a unified plugin marketplace. Built following the official [MCP SDK](https://github.com/modelcontextprotocol/typescript-sdk) best practices using the high-level `McpServer` API.
+## Why this marketplace exists
+Claude-m is optimized for high-value Microsoft tasks:
+- **Review Azure IaC and live resources** for risk/cost hot spots.
+- **Triage DevOps and collaboration workflows** through Teams/Outlook context.
+- **Analyze spreadsheets and operational data** from Excel/SharePoint quickly.
 
----
+This repo intentionally keeps the marketplace small, strict, and maintainable.
 
-## Features
-
-✨ **Plugin Marketplace** — Discover and explore Microsoft product integrations
-🔍 **Smart Search** — Find plugins by keyword or capability
-🛠️ **25+ Tools** — Comprehensive Microsoft product APIs
-📦 **Modular Design** — Each plugin is independently loadable
-✅ **Production Ready** — Built with TypeScript, Zod validation, and comprehensive tests
-🎯 **MCP Native** — Uses official `@modelcontextprotocol/sdk` v1.27.1+
-
----
-
-## Architecture
-
-This MCP server uses the modern `McpServer` high-level API (not the deprecated low-level `Server` class) for optimal compatibility with Claude Desktop and Claude Code.
-
-### Key Components
-
-- **`src/types.ts`** — Shared types: `PluginManifest`, `PluginAuth`, `PluginResult`
-- **`src/plugins/base.ts`** — Abstract `BasePlugin` with bearer-token fetch helpers (`graphGet`, `graphPost`)
-- **`src/registry.ts`** — Loads `registry/*.json` manifests at runtime; works in both ESM and CJS
-- **`src/index.ts`** — MCP server using `McpServer`: dynamic tool registration with Zod schemas
-
-Each plugin validates arguments via Zod and maps tool names to Microsoft Graph/ARM REST calls.
-
----
-
-## Plugins
-
-| Plugin | Product | Tools |
-|--------|---------|-------|
-| **teams** | Microsoft Teams | Send messages, create meetings, list teams & channels |
-| **excel** | Microsoft Excel | Read/write ranges, list worksheets, create tables |
-| **outlook** | Microsoft Outlook | Send emails, list inbox, create & list calendar events |
-| **azure** | Microsoft Azure | List subscriptions, resource groups, resources & resource details |
-| **sharepoint** | Microsoft SharePoint | List sites, list/upload/download files |
-
----
-
-## Prerequisites
-
-- **Node.js** ≥ 18
-- An **Azure AD / Microsoft Entra** app registration with the required API permissions (see each plugin's `registry/*.json` for the required scopes)
-- An access token or OAuth credentials for the registered application
-
----
-
-## Installation
+## Quick start
 
 ```bash
-npm install
-npm run build
-```
-
----
-
-## Configuration
-
-Set the following environment variables before starting the server:
-
-| Variable | Description |
-|----------|-------------|
-| `MICROSOFT_CLIENT_ID` | Azure AD app client ID |
-| `MICROSOFT_CLIENT_SECRET` | Azure AD app client secret |
-| `MICROSOFT_TENANT_ID` | Azure AD tenant ID |
-| `MICROSOFT_ACCESS_TOKEN` | *(Optional)* Pre-issued access token — skips the OAuth flow |
-
----
-
-## Usage
-
-### Option 1: Install from Claude Code Plugin Marketplace (Recommended)
-
-The easiest way to use Claude-m is through the Claude Code plugin marketplace:
-
-```bash
-# Add the marketplace
 /plugin marketplace add markus41/Claude-m
-
-# Install specific plugins
-/plugin install "Microsoft Teams MCP"
-/plugin install "Microsoft Excel MCP"
-/plugin install "Microsoft Outlook MCP"
-/plugin install "Microsoft Azure MCP"
-/plugin install "Microsoft SharePoint MCP"
+/plugin install "Microsoft Azure MCP@Claude-m Microsoft Marketplace"
 ```
 
-This will automatically configure the MCP server with the appropriate tools for each plugin.
+## Copy-paste sessions
 
-### Option 2: Manual MCP Server Configuration
+### 1) Add the marketplace
+```bash
+/plugin marketplace add markus41/Claude-m
+/plugin marketplace list
+```
 
-#### Run the MCP server
+### 2) Install a Microsoft plugin from this marketplace
+```bash
+/plugin install "Microsoft Teams MCP@Claude-m Microsoft Marketplace"
+```
+
+### 3) Run a realistic task prompt
+```text
+Use Microsoft Azure MCP to list all resource groups in subscription <subscription-id>,
+identify resources with no recent activity, and suggest cleanup candidates.
+```
+
+## Opinionated flows
+
+1. **Set up Microsoft collaboration stack**
+   - Install Teams + Outlook + SharePoint plugins.
+   - Prompt: “Audit communication and file handoff risks for this week and produce actions.”
+2. **Azure governance review**
+   - Install Azure plugin.
+   - Prompt: “List subscriptions/resource groups/resources, then flag policy drift and likely cost waste.”
+
+## Marketplace structure guidance
+- `.claude-plugin/marketplace.json` is intentionally minimal (short name, clear description, only maintained plugins).
+- `strict: true` is used for all first-party plugins in this repo.
+- If you need heavy command/agent reshaping for third-party plugins, put those entries in a separate marketplace repo with `strict: false` only where required.
+- Prefer multiple focused marketplace repos (e.g. `claude-msft-suite`, `claude-devtools`) over a single giant catalog.
+
+## Validation commands
+Run the same checks locally and in CI:
 
 ```bash
-MICROSOFT_ACCESS_TOKEN=<token> npm start
+claude plugin validate .
+/plugin validate .
+npm run validate:marketplace
+npm run validate:plugins
+npm run validate:all
 ```
 
-#### Configure in Claude Desktop
+`validate:marketplace` checks `.claude-plugin/marketplace.json`; `validate:plugins` checks every `plugins/*/plugin.json`.
 
-Add the following entry to your `claude_desktop_config.json`:
-
-```json
-{
-  "mcpServers": {
-    "claude-m": {
-      "command": "node",
-      "args": ["/path/to/Claude-m/dist/index.js"],
-      "env": {
-        "MICROSOFT_CLIENT_ID": "<client-id>",
-        "MICROSOFT_CLIENT_SECRET": "<client-secret>",
-        "MICROSOFT_TENANT_ID": "<tenant-id>",
-        "MICROSOFT_ACCESS_TOKEN": "<access-token>"
-      }
-    }
-  }
-}
-```
-
-#### Configure in Claude Code
-
-Claude Code can automatically discover MCP servers configured in your `claude_desktop_config.json`. Alternatively, you can configure it directly in your project's `.claude/config.json`:
-
-```json
-{
-  "mcpServers": {
-    "claude-m": {
-      "command": "node",
-      "args": ["/absolute/path/to/Claude-m/dist/index.js"],
-      "env": {
-        "MICROSOFT_ACCESS_TOKEN": "your-token-here"
-      }
-    }
-  }
-}
-```
-
-**Note**: Always use absolute paths in MCP server configuration.
-
----
-
-## Marketplace Tools
-
-The marketplace provides powerful discovery tools that are always available:
-
-| Tool | Description |
-|------|-------------|
-| `marketplace_list_plugins` | List all available Microsoft plugins with descriptions, versions, and required scopes |
-| `marketplace_get_plugin` | Get detailed information about a specific plugin by its ID |
-| `marketplace_search_plugins` | Search plugins by keyword in name, description, or tool names |
-| `marketplace_list_tools` | List all available tools across all plugins (optionally filter by plugin ID) |
-
-### Example Usage
-
-```typescript
-// Discover all plugins
-await callTool("marketplace_list_plugins", {});
-
-// Find plugins related to email
-await callTool("marketplace_search_plugins", { keyword: "email" });
-
-// Get details about the Teams plugin
-await callTool("marketplace_get_plugin", { pluginId: "teams" });
-
-// List all tools
-await callTool("marketplace_list_tools", {});
-
-// List only Outlook tools
-await callTool("marketplace_list_tools", { pluginId: "outlook" });
-```
-
----
+## Org allow-listing (`strictKnownMarketplaces`)
+For org rollouts, admins can allow-list this marketplace URL/repo with `strictKnownMarketplaces` in their Claude policy so installs resolve only from approved sources.
 
 ## Development
 
 ```bash
-# Type-check
-npm run lint
-
-# Build
+npm install
 npm run build
-
-# Test
+npm run lint
 npm test
-
-# Test with coverage
-npm run test:coverage
 ```
 
-### Project structure
-
-```
-Claude-m/
-├── .claude-plugin/          # Claude Code marketplace metadata
-│   └── marketplace.json     # Marketplace configuration
-├── plugins/                 # Claude Code plugin definitions
-│   ├── teams/
-│   │   ├── plugin.json     # Teams plugin manifest
-│   │   └── README.md       # Teams plugin documentation
-│   ├── excel/
-│   │   ├── plugin.json     # Excel plugin manifest
-│   │   └── README.md       # Excel plugin documentation
-│   ├── outlook/
-│   │   ├── plugin.json     # Outlook plugin manifest
-│   │   └── README.md       # Outlook plugin documentation
-│   ├── azure/
-│   │   ├── plugin.json     # Azure plugin manifest
-│   │   └── README.md       # Azure plugin documentation
-│   └── sharepoint/
-│       ├── plugin.json     # SharePoint plugin manifest
-│       └── README.md       # SharePoint plugin documentation
-├── src/
-│   ├── index.ts            # MCP server entry point
-│   ├── registry.ts         # Loads plugin manifests from registry/
-│   ├── types.ts            # Shared TypeScript types
-│   └── plugins/
-│       ├── base.ts         # Abstract BasePlugin class
-│       ├── teams.ts        # Microsoft Teams plugin
-│       ├── excel.ts        # Microsoft Excel plugin
-│       ├── outlook.ts      # Microsoft Outlook plugin
-│       ├── azure.ts        # Microsoft Azure plugin
-│       └── sharepoint.ts   # Microsoft SharePoint plugin
-├── registry/               # Internal JSON plugin manifests
-│   ├── teams.json
-│   ├── excel.json
-│   ├── outlook.json
-│   ├── azure.json
-│   └── sharepoint.json
-└── tests/                  # Jest test suites
-    ├── registry.test.ts
-    └── plugins.test.ts
-```
-
----
-
-## License
-
-ISC
-
+## Roadmap
+- SharePoint automation expansions (bulk operations and metadata workflows)
+- Power BI plugin for dataset/report inspection
+- Teams automation helpers for channel lifecycle and meeting operations

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
       "devDependencies": {
         "@types/jest": "^29.5.14",
         "@types/node": "^22.0.0",
+        "ajv": "^8.17.1",
         "jest": "^29.7.0",
         "jest-util": "^29.7.0",
         "ts-jest": "^29.3.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "start": "node dist/index.js",
     "test": "jest",
     "test:coverage": "jest --coverage",
-    "lint": "tsc --noEmit"
+    "lint": "tsc --noEmit",
+    "validate:marketplace": "node scripts/validate-marketplace.mjs",
+    "validate:all": "npm run validate:marketplace && npm run validate:plugins",
+    "validate:plugins": "node scripts/validate-plugins.mjs"
   },
   "repository": {
     "type": "git",
@@ -41,7 +44,8 @@
     "jest": "^29.7.0",
     "jest-util": "^29.7.0",
     "ts-jest": "^29.3.0",
-    "typescript": "^5.8.2"
+    "typescript": "^5.8.2",
+    "ajv": "^8.17.1"
   },
   "jest": {
     "testEnvironment": "node",

--- a/scripts/validate-marketplace.mjs
+++ b/scripts/validate-marketplace.mjs
@@ -1,0 +1,49 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import Ajv from 'ajv';
+
+const marketplacePath = path.resolve('.claude-plugin/marketplace.json');
+const raw = fs.readFileSync(marketplacePath, 'utf8');
+const data = JSON.parse(raw);
+
+const schema = {
+  type: 'object',
+  required: ['name', 'description', 'plugins'],
+  additionalProperties: true,
+  properties: {
+    name: { type: 'string', minLength: 1 },
+    description: { type: 'string', minLength: 1 },
+    plugins: {
+      type: 'array',
+      minItems: 1,
+      items: {
+        type: 'object',
+        required: ['name', 'source', 'description'],
+        additionalProperties: true,
+        properties: {
+          name: { type: 'string', minLength: 1 },
+          source: { type: 'string', minLength: 1 },
+          description: { type: 'string', minLength: 1 },
+          tags: {
+            type: 'array',
+            items: { type: 'string', minLength: 1 }
+          },
+          category: { type: 'string', minLength: 1 }
+        }
+      }
+    }
+  }
+};
+
+const ajv = new Ajv({ allErrors: true });
+const validate = ajv.compile(schema);
+
+if (!validate(data)) {
+  console.error('Marketplace schema validation failed:');
+  for (const error of validate.errors ?? []) {
+    console.error(`- ${error.instancePath || '/'} ${error.message}`);
+  }
+  process.exit(1);
+}
+
+console.log('Marketplace schema validation passed.');

--- a/scripts/validate-plugins.mjs
+++ b/scripts/validate-plugins.mjs
@@ -1,0 +1,62 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import Ajv from 'ajv';
+
+const pluginsDir = path.resolve('plugins');
+const pluginFolders = fs.readdirSync(pluginsDir, { withFileTypes: true }).filter((entry) => entry.isDirectory());
+
+const schema = {
+  type: 'object',
+  required: ['name', 'version', 'description', 'author', 'mcpServer'],
+  additionalProperties: true,
+  properties: {
+    name: { type: 'string', minLength: 1 },
+    version: { type: 'string', minLength: 1 },
+    description: { type: 'string', minLength: 1 },
+    author: { type: 'string', minLength: 1 },
+    mcpServer: {
+      type: 'object',
+      required: ['command', 'args'],
+      additionalProperties: true,
+      properties: {
+        command: { type: 'string', minLength: 1 },
+        args: {
+          type: 'array',
+          minItems: 1,
+          items: { type: 'string', minLength: 1 }
+        }
+      }
+    }
+  }
+};
+
+const ajv = new Ajv({ allErrors: true });
+const validate = ajv.compile(schema);
+let hasError = false;
+
+for (const folder of pluginFolders) {
+  const manifestPath = path.join(pluginsDir, folder.name, 'plugin.json');
+  if (!fs.existsSync(manifestPath)) {
+    console.error(`Missing plugin manifest: ${manifestPath}`);
+    hasError = true;
+    continue;
+  }
+
+  const raw = fs.readFileSync(manifestPath, 'utf8');
+  const data = JSON.parse(raw);
+  const valid = validate(data);
+
+  if (!valid) {
+    hasError = true;
+    console.error(`Validation failed for ${manifestPath}:`);
+    for (const error of validate.errors ?? []) {
+      console.error(`- ${error.instancePath || '/'} ${error.message}`);
+    }
+  }
+}
+
+if (hasError) {
+  process.exit(1);
+}
+
+console.log('Plugin manifest validation passed.');


### PR DESCRIPTION
## Summary
- Simplified `.claude-plugin/marketplace.json` to a focused Microsoft marketplace catalog with concise plugin descriptions and `strict: true` for maintained first-party plugins.
- Added a concise `CLAUDE.md` with:
  - `/plugin marketplace add owner/repo` usage
  - concrete install/validate commands
  - prompt examples and two opinionated Microsoft flows
- Reworked `README.md` to emphasize Microsoft workflow value, copy-paste install sessions, validation commands, strictKnownMarketplaces guidance, and a roadmap section.
- Added CI automation (`.github/workflows/ci.yml`) to run build/lint/test plus marketplace/plugin manifest validation on pushes and PRs.
- Added JSON validation scripts:
  - `scripts/validate-marketplace.mjs` (Ajv schema checks for marketplace entries)
  - `scripts/validate-plugins.mjs` (Ajv checks for all `plugins/*/plugin.json`)
- Added npm scripts:
  - `validate:marketplace`
  - `validate:plugins`
  - `validate:all`

## Validation run
- `npm run validate:marketplace`
- `npm run validate:plugins`

Both commands passed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a474462d1c832a93940421309aa3a3)