### PR TITLE
Add Codex workspace configuration and AGENTS guidelines for Claude-m marketplace

### DIFF
--- a/.codex
+++ b/.codex
@@ -1,0 +1,55 @@
+# Codex Workspace Configuration for Claude-m Marketplace
+
+## Purpose
+This repository is a Codex-ready mirror of Claude Code marketplace plugins focused on Microsoft ecosystems.
+Use this file to align Codex behavior with Claude plugin discovery, installation, validation, and skill activation.
+
+## Canonical Sources
+1. `CLAUDE.md` (root): plugin catalog, install slugs, quick-start, validation commands, and opinionated flows.
+2. Per-plugin docs under each top-level directory:
+   - `README.md`
+   - `skills/**/SKILL.md`
+   - `commands/*.md`
+   - `agents/*.md`
+
+## Codex Operating Rules
+1. Resolve plugin names/slugs exactly as documented in `CLAUDE.md`.
+2. Load context progressively:
+   - first plugin `README.md`
+   - then matching `SKILL.md`
+   - then specific `references/` or `examples/` files only when required.
+3. Prefer deterministic command docs in `commands/*.md` over ad-hoc procedures.
+4. For audit/review prompts, follow the matching `agents/*.md` rubric and output format.
+5. Keep context lean; avoid bulk-loading unrelated references.
+
+## Marketplace Compatibility
+Preserve Claude marketplace UX and strings exactly:
+
+```bash
+/plugin marketplace add markus41/Claude-m
+/plugin install <plugin-name>@claude-m-microsoft-marketplace
+/plugin validate .
+claude plugin validate .
+npm run validate:all
+```
+
+## Skill Extensibility Standards
+When creating/updating plugin skills:
+- Put core triggering/usage guidance in `skills/<skill-name>/SKILL.md`.
+- Put detailed technical docs in `skills/<skill-name>/references/`.
+- Put reusable examples in `skills/<skill-name>/examples/`.
+- Keep trigger keywords explicit, user-phrase-oriented, and domain-bounded.
+- Prefer concrete patterns and templates over vague prose.
+
+## Documentation Quality Standards
+- Do not invent plugin slugs, endpoints, or command names not present in repository docs.
+- Use secure defaults (least privilege, explicit tenant/subscription/workspace scoping).
+- Include prerequisites and validation checks for generated workflows.
+- Keep terminology consistent across root catalog and plugin-local docs.
+
+## Contribution Checklist
+For any plugin or marketplace update:
+1. Update root `CLAUDE.md` plugin table when installables change.
+2. Keep plugin `README.md`, `SKILL.md`, command docs, and agent docs mutually consistent.
+3. Ensure setup/validation commands are runnable as written.
+4. Add examples that reflect real Microsoft cloud/productivity/security workflows.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,57 @@
+# AGENTS.md
+
+## Scope
+Applies to the entire `/workspace/Claude-m` repository unless a deeper `AGENTS.md` overrides it.
+
+## Mission
+Build and maintain high-quality Claude plugins and marketplace metadata with first-class Codex compatibility.
+Use root `CLAUDE.md` as the canonical marketplace source for plugin names, install slugs, categories, and validation flow.
+
+## Required Build Workflow (Claude Plugins + Marketplace)
+1. Read root `CLAUDE.md` first.
+2. Confirm/update plugin metadata consistency across:
+   - plugin folder name
+   - install slug
+   - category/description
+   - README capability claims
+3. Ensure plugin structure includes (where applicable):
+   - `.claude-plugin/plugin.json`
+   - `skills/<name>/SKILL.md`
+   - `commands/*.md`
+   - `agents/*.md`
+   - `README.md`
+4. Validate that command docs are executable and deterministic.
+5. Validate reviewer agents have explicit output format and actionable checks.
+
+## Codex Documentation Expectations
+When authoring docs for Codex use:
+- Prefer precise paths and exact command examples.
+- Keep SKILL docs concise and use progressive disclosure.
+- Reference only needed files from `SKILL.md` (avoid broad, deep reference chasing).
+- Encode clear trigger phrases so capability routing is predictable.
+- State prerequisites (auth, tenant, subscription, permissions) explicitly.
+
+## Marketplace Correctness Rules
+- Installation pattern must remain:
+  - `/plugin install <plugin-name>@claude-m-microsoft-marketplace`
+- Marketplace bootstrap must remain:
+  - `/plugin marketplace add markus41/Claude-m`
+- Any new/renamed plugin requires root catalog updates in `CLAUDE.md`.
+- Do not publish contradictory names/slugs across docs.
+
+## Writing Standards
+- Use short imperative instructions.
+- Keep sections skimmable with headings and bullets.
+- Include: purpose, when to use, inputs/prereqs, outputs, and validation.
+- Avoid over-claiming runtime behavior not represented by repository assets.
+
+## Quality Gates Before Merge
+- Cross-file consistency check passes (`CLAUDE.md` ↔ plugin READMEs ↔ skills/commands/agents).
+- Trigger keywords in `SKILL.md` reflect natural user prompts.
+- Validation commands are present and accurate.
+- Examples are relevant to Microsoft ecosystems and safe by default.
+
+## Safety / Non-goals
+- Do not fabricate APIs, MCP tools, or command support.
+- Do not duplicate large references across multiple plugins; link to canonical docs.
+- Do not add extra process docs unless requested; prefer concise, maintainable guidance.


### PR DESCRIPTION
### Motivation
- Provide a Codex-aligned workspace configuration and agent guidance to standardize plugin discovery, validation, and documentation for the Claude-m Microsoft-focused marketplace.

### Description
- Add `.codex` to define canonical sources, Codex operating rules, marketplace compatibility examples, skill extensibility standards, documentation quality rules, and a contribution checklist. 
- Add `AGENTS.md` to prescribe repository-wide agent mission, required build workflow, documentation expectations, marketplace correctness rules, writing standards, quality gates, and safety/non-goals. 
- Include explicit command examples and required file/structure expectations such as `CLAUDE.md`, `skills/<name>/SKILL.md`, `commands/*.md`, and `.claude-plugin/plugin.json` where applicable.

### Testing
- No automated tests were added or run for these documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4b40a1f78832aba821519703f8b4f)