### PR TITLE
Standardize Azure/Power Automate command docs with frontmatter and structured execution guidance

### DIFF
--- a/azure-cost-governance/commands/azure-budget-check.md
+++ b/azure-cost-governance/commands/azure-budget-check.md
@@ -1,2 +1,64 @@
-Review budget utilization and forecast overrun risk.
-Return budget status, breach likelihood, and suggested interventions.
+---
+name: azure-budget-check
+description: Assess Azure budget health, forecast overrun risk, and recommend practical interventions with owner-ready output.
+argument-hint: "<scope> [--budget-name <name>] [--timeframe <MTD|QTD|monthly>] [--alert-thresholds <50,80,100>] [--forecast-days <30>]"
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Write
+  - Edit
+  - AskUserQuestion
+---
+
+# Azure Budget Check
+
+## Purpose
+Review budget utilization and forecast breach likelihood for a target Azure scope.
+
+## When to use
+- Finance or platform teams need current budget status before month-end.
+- You need proactive actions when burn rate exceeds plan.
+- You need an auditable budget-health summary for stakeholders.
+
+## Required inputs/prereqs
+- Budget scope and budget name (or confirmation to use default budget at scope).
+- Current period spend and configured thresholds (50/80/100% default if omitted).
+- Forecast horizon (default 30 days).
+- Access to cost and budget data at the target scope.
+
+## Step-by-step execution procedure
+1. Confirm scope and locate budget(s) in that scope.
+2. Resolve thresholds and period window.
+3. Compute:
+   - actual spend to date,
+   - remaining budget,
+   - burn rate,
+   - projected end-of-period spend.
+4. Classify risk (`low`, `medium`, `high`, `critical`) using threshold proximity and forecast trend.
+5. Produce intervention options (for example: rightsizing, schedule-based shutdown, commitment review) with expected impact range.
+
+**Concrete example invocation**
+```text
+/azure-budget-check /subscriptions/00000000-0000-0000-0000-000000000000 --budget-name prod-monthly --timeframe monthly --alert-thresholds 60,85,100 --forecast-days 21
+```
+
+**Failure-mode example**
+```text
+/azure-budget-check /subscriptions/00000000-0000-0000-0000-000000000000 --alert-thresholds abc
+```
+Expected assistant behavior: reject non-numeric thresholds, explain valid format, and provide a corrected sample.
+
+## Output schema/format expected from the assistant
+Return in this order:
+1. `BudgetStatus` table with columns: `BudgetName`, `Scope`, `Actual`, `Budget`, `UtilizationPct`, `Forecast`, `ForecastPct`, `Risk`.
+2. `Interventions` list with `Action`, `EstimatedSavingsRange`, `Owner`, `Urgency`.
+3. `AssumptionsAndGaps` bullets for any missing telemetry or uncertain estimates.
+
+## Validation checklist
+- Command name is `azure-budget-check` and matches file name.
+- Thresholds are numeric percentages and sorted ascending.
+- Forecast and utilization percentages are present.
+- Risk tier is explicitly assigned with rationale.
+- Output includes status table, interventions, and assumptions/gaps.

--- a/azure-cost-governance/commands/azure-cost-query.md
+++ b/azure-cost-governance/commands/azure-cost-query.md
@@ -1,2 +1,80 @@
-Create a cost query plan and output format for Azure Cost Management.
-Include dimensions, filters, granularity, and anomaly thresholds.
+---
+name: azure-cost-query
+description: Build a deterministic Azure Cost Management query plan with scope, filters, granularity, anomaly thresholds, and a report-ready response schema.
+argument-hint: "<scope> [--timeframe <MTD|QTD|last-30-days|custom>] [--start <YYYY-MM-DD>] [--end <YYYY-MM-DD>] [--group-by <dimension,...>] [--filter <key=value,...>] [--granularity <daily|monthly>]"
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Write
+  - Edit
+  - AskUserQuestion
+---
+
+# Azure Cost Query
+
+## Purpose
+Create an Azure Cost Management query definition the assistant can execute or hand off without ambiguity.
+
+## When to use
+- You need spend analysis by subscription, resource group, service, or tag.
+- You need a baseline for anomaly detection or chargeback reporting.
+- You want a reproducible query before dashboarding or automation.
+
+## Required inputs/prereqs
+- Azure billing access to the target scope (`subscription`, `resourceGroup`, or billing scope).
+- Time range (`--timeframe` or `--start` + `--end`).
+- At least one grouping dimension (for example: `ResourceGroup`, `ServiceName`, `Tag:CostCenter`).
+- Optional filter set and anomaly threshold (percentage or absolute delta).
+
+## Step-by-step execution procedure
+1. Resolve scope and validate the caller has read permissions.
+2. Normalize timeframe:
+   - Use preset timeframe when provided.
+   - Otherwise require both `--start` and `--end`.
+3. Parse grouping list and filters into deterministic key/value pairs.
+4. Set granularity (`daily` for short windows, `monthly` for trend windows unless overridden).
+5. Build query plan with:
+   - metric (`PreTaxCost` unless user states otherwise),
+   - aggregation (`sum`),
+   - grouping,
+   - filters,
+   - anomaly rule.
+6. Return both human summary and machine-consumable schema.
+
+**Concrete example invocation**
+```text
+/azure-cost-query /subscriptions/00000000-0000-0000-0000-000000000000 --timeframe last-30-days --group-by ResourceGroup,ServiceName --filter Tag:Environment=Prod --granularity daily
+```
+
+**Failure-mode example**
+```text
+/azure-cost-query /subscriptions/00000000-0000-0000-0000-000000000000 --start 2026-02-01 --group-by ResourceGroup
+```
+Expected assistant behavior: fail fast because `--end` is missing, then return a short remediation prompt listing required fields.
+
+## Output schema/format expected from the assistant
+Return in this order:
+1. `Summary` (3-6 bullets).
+2. `QueryPlan` JSON block:
+   ```json
+   {
+     "scope": "string",
+     "timeframe": {"mode": "preset|custom", "preset": "string|null", "start": "YYYY-MM-DD|null", "end": "YYYY-MM-DD|null"},
+     "metric": "PreTaxCost",
+     "aggregation": "sum",
+     "granularity": "daily|monthly",
+     "groupBy": ["dimension"],
+     "filters": [{"key": "string", "operator": "Equals", "value": "string"}],
+     "anomalyRule": {"type": "percent|absolute", "threshold": "number", "lookbackDays": "number"}
+   }
+   ```
+3. `ValidationNotes` (permissions, missing inputs, and confidence).
+
+## Validation checklist
+- Command name is `azure-cost-query` and matches file name.
+- Scope is explicit and valid.
+- Timeframe is complete (`preset` or full custom range).
+- Grouping/filter keys are normalized and deterministic.
+- Output includes `Summary`, `QueryPlan` JSON, and `ValidationNotes`.

--- a/azure-cost-governance/commands/azure-idle-resources.md
+++ b/azure-cost-governance/commands/azure-idle-resources.md
@@ -1,2 +1,61 @@
-Identify likely idle resources and propose right-sizing or shutdown actions.
-Include confidence level and rollback considerations.
+---
+name: azure-idle-resources
+description: Detect likely idle Azure resources, rank optimization actions, and include confidence plus rollback considerations.
+argument-hint: "<scope> [--lookback-days <30>] [--resource-types <vm,disk,appgw,...>] [--min-monthly-savings <amount>] [--include-rollback]"
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Write
+  - Edit
+  - AskUserQuestion
+---
+
+# Azure Idle Resources
+
+## Purpose
+Identify underutilized resources and recommend safe, reversible cost optimizations.
+
+## When to use
+- You need quick savings candidates without major architecture changes.
+- Monthly FinOps review requires an idle-resource backlog.
+- You need shutdown/deallocation candidates with risk notes.
+
+## Required inputs/prereqs
+- Scope (subscription/resource group) and lookback window.
+- Activity signals (CPU, network, IOPS, request count, job history as applicable).
+- Business criticality context (production vs non-production tags).
+- Optional minimum savings threshold for prioritization.
+
+## Step-by-step execution procedure
+1. Resolve scope and resource-type filters.
+2. Gather activity metrics for the lookback period.
+3. Mark resources as idle candidates using explicit heuristics per type.
+4. Assign confidence (`high|medium|low`) based on metric completeness and consistency.
+5. Propose actions (`stop`, `deallocate`, `resize`, `delete`) with rollback guidance.
+6. Rank by estimated monthly savings and operational risk.
+
+**Concrete example invocation**
+```text
+/azure-idle-resources /subscriptions/00000000-0000-0000-0000-000000000000 --lookback-days 45 --resource-types vm,disk,appgw --min-monthly-savings 100 --include-rollback
+```
+
+**Failure-mode example**
+```text
+/azure-idle-resources /subscriptions/00000000-0000-0000-0000-000000000000 --lookback-days -7
+```
+Expected assistant behavior: reject invalid negative lookback values and request a positive integer.
+
+## Output schema/format expected from the assistant
+Return in this order:
+1. `IdleCandidates` table: `ResourceId`, `Type`, `IdleSignalSummary`, `EstimatedMonthlySavings`, `Confidence`, `Risk`.
+2. `RecommendedActions` table: `ResourceId`, `Action`, `RollbackPlan`, `ChangeWindowSuggestion`.
+3. `TriageSummary` bullets: top savings opportunities and blockers.
+
+## Validation checklist
+- Command name is `azure-idle-resources` and matches file name.
+- Lookback window is a positive integer.
+- Confidence score is provided for each candidate.
+- Rollback guidance is present for every destructive or disruptive action.
+- Output includes candidate table, action table, and triage summary.

--- a/azure-policy-security/commands/drift-analysis.md
+++ b/azure-policy-security/commands/drift-analysis.md
@@ -1,2 +1,62 @@
-Analyze policy drift versus baseline and summarize high-priority violations,
-exemptions, and exception aging.
+---
+name: drift-analysis
+description: Compare current Azure Policy state to baseline and surface high-priority drift, exception aging, and enforcement regressions.
+argument-hint: "<scope> [--baseline <name>] [--since <YYYY-MM-DD>] [--severity <high|medium|low>] [--include-exemptions]"
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Write
+  - Edit
+  - AskUserQuestion
+---
+
+# Drift Analysis
+
+## Purpose
+Detect compliance drift from expected policy baseline and rank what to fix first.
+
+## When to use
+- Continuous compliance monitoring catches regressions.
+- Change windows introduced new non-compliant resources.
+- Exception lists may be aging beyond accepted policy.
+
+## Required inputs/prereqs
+- Target scope and baseline reference.
+- Time boundary for drift detection (`--since` recommended).
+- Access to policy compliance snapshots/events.
+- Exemption data with creation dates and expiry metadata.
+
+## Step-by-step execution procedure
+1. Load baseline policy expectations for target scope.
+2. Compare current assignments/compliance states to baseline snapshot.
+3. Identify new drifts: missing assignment, effect downgrade, non-compliant growth.
+4. Analyze exemptions by age, owner, and expiry status.
+5. Rank findings by severity and blast radius.
+6. Produce remediation queue with measurable closure criteria.
+
+**Concrete example invocation**
+```text
+/drift-analysis /subscriptions/00000000-0000-0000-0000-000000000000 --baseline cis-azure-1.5 --since 2026-01-01 --severity high --include-exemptions
+```
+
+**Failure-mode example**
+```text
+/drift-analysis /subscriptions/00000000-0000-0000-0000-000000000000 --since 01-01-2026
+```
+Expected assistant behavior: reject invalid date format and request ISO `YYYY-MM-DD`.
+
+## Output schema/format expected from the assistant
+Return in this order:
+1. `DriftSummary` (`TotalFindings`, `HighSeverity`, `AffectedScopes`, `PeriodStart`).
+2. `DriftFindings` table: `FindingType`, `Scope`, `Severity`, `Evidence`, `RecommendedFix`.
+3. `ExceptionAging` table: `ExemptionId`, `Scope`, `AgeDays`, `ExpiresOn`, `Owner`, `Risk`.
+4. `RemediationQueue` ordered list with `Priority`, `Action`, `SuccessMetric`.
+
+## Validation checklist
+- Command name is `drift-analysis` and matches file name.
+- Baseline and period start are explicit.
+- Severity ranking and evidence are included.
+- Exception aging is quantified in days.
+- Output includes summary, findings, aging, and remediation queue.

--- a/azure-policy-security/commands/policy-coverage.md
+++ b/azure-policy-security/commands/policy-coverage.md
@@ -1,2 +1,62 @@
-Assess policy assignment coverage and report gaps by scope,
-including key control categories.
+---
+name: policy-coverage
+description: Evaluate Azure Policy assignment coverage by scope and control category, then report actionable guardrail gaps.
+argument-hint: "<scope> [--baseline <cis|nist|custom>] [--include-exemptions] [--group-by <scope|category|initiative>]"
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Write
+  - Edit
+  - AskUserQuestion
+---
+
+# Policy Coverage
+
+## Purpose
+Measure how completely required policies are assigned and enforced across target Azure scopes.
+
+## When to use
+- Security governance reviews need coverage metrics.
+- New subscriptions/management groups must be checked for baseline adherence.
+- Audit prep requires clear policy gap reporting.
+
+## Required inputs/prereqs
+- Target scope (management group, subscription, or resource group).
+- Baseline/control framework (`cis`, `nist`, or documented custom baseline).
+- Policy/initiative inventory and assignment visibility.
+- Optional exemption visibility for adjusted coverage math.
+
+## Step-by-step execution procedure
+1. Resolve scope hierarchy and baseline controls.
+2. Map each control to expected policy definition/initiative.
+3. Evaluate assignment presence and enforcement mode.
+4. Compute coverage percentages by category and scope.
+5. Identify gaps, overlap, and risky exemption patterns.
+6. Return prioritized remediation sequence.
+
+**Concrete example invocation**
+```text
+/policy-coverage /providers/Microsoft.Management/managementGroups/contoso-root --baseline cis --include-exemptions --group-by category
+```
+
+**Failure-mode example**
+```text
+/policy-coverage --baseline nist
+```
+Expected assistant behavior: fail because scope is missing; return required argument list and a corrected command template.
+
+## Output schema/format expected from the assistant
+Return in this order:
+1. `CoverageSummary` (`OverallCoveragePct`, `ScopesReviewed`, `Baseline`).
+2. `CoverageByCategory` table: `Category`, `ExpectedControls`, `CoveredControls`, `CoveragePct`, `HighRiskGaps`.
+3. `GapBacklog` table: `Gap`, `Scope`, `RecommendedPolicy`, `Priority`, `Owner`.
+4. `Notes` bullets for exemptions and assumptions.
+
+## Validation checklist
+- Command name is `policy-coverage` and matches file name.
+- Scope and baseline are explicit.
+- Coverage percentages are computed and shown.
+- High-risk gaps are prioritized.
+- Output includes summary, category table, gap backlog, and notes.

--- a/azure-policy-security/commands/remediation-plan.md
+++ b/azure-policy-security/commands/remediation-plan.md
@@ -1,2 +1,62 @@
-Build a remediation plan with sequencing, risk notes,
-owner mapping, and measurable completion criteria.
+---
+name: remediation-plan
+description: Build a sequenced Azure policy/security remediation plan with owner mapping, risk notes, and measurable completion criteria.
+argument-hint: "<scope> [--input <coverage|drift-report>] [--window <days>] [--owners <team:aad-group,...>] [--max-parallel <n>]"
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Write
+  - Edit
+  - AskUserQuestion
+---
+
+# Remediation Plan
+
+## Purpose
+Convert policy/compliance findings into an execution-ready remediation roadmap.
+
+## When to use
+- After policy coverage or drift analysis identifies actionable gaps.
+- Program teams need ownership and sequencing for closure.
+- Leadership needs timeline and measurable risk reduction targets.
+
+## Required inputs/prereqs
+- Target scope and trusted findings source (`coverage` or `drift` report).
+- Available remediation window and parallel execution capacity.
+- Owner/team mapping for each remediation domain.
+- Change-management constraints (maintenance windows, approval gates).
+
+## Step-by-step execution procedure
+1. Ingest findings and normalize by severity, dependency, and blast radius.
+2. Group work into remediation waves (quick wins, medium effort, structural fixes).
+3. Assign owners and due dates using workload and team capability.
+4. Add risk notes and rollback/contingency requirements per task.
+5. Define completion criteria and verification command/check for each task.
+6. Produce a delivery plan with milestones and status tracking format.
+
+**Concrete example invocation**
+```text
+/remediation-plan /providers/Microsoft.Management/managementGroups/contoso-root --input drift-report --window 45 --owners platform:sg-platform,security:sg-secops --max-parallel 6
+```
+
+**Failure-mode example**
+```text
+/remediation-plan /providers/Microsoft.Management/managementGroups/contoso-root --window 0
+```
+Expected assistant behavior: reject non-positive remediation window and request a valid day range.
+
+## Output schema/format expected from the assistant
+Return in this order:
+1. `PlanSummary` (`Scope`, `TotalTasks`, `WindowDays`, `TargetRiskReductionPct`).
+2. `ExecutionPlan` table: `Wave`, `Task`, `Owner`, `DueDate`, `Dependency`, `RiskNote`, `SuccessCriteria`.
+3. `Milestones` list with date and measurable outcome.
+4. `TrackingTemplate` markdown snippet for weekly status.
+
+## Validation checklist
+- Command name is `remediation-plan` and matches file name.
+- Input findings source is explicit.
+- Every task has owner, due date, and success criteria.
+- Dependencies and risk notes are present.
+- Output includes summary, execution plan, milestones, and tracking template.

--- a/power-automate/commands/flow-debug.md
+++ b/power-automate/commands/flow-debug.md
@@ -1,2 +1,62 @@
-Analyze a failed flow run and provide root-cause hypotheses,
-validation steps, and safe remediations.
+---
+name: flow-debug
+description: Diagnose failed Power Automate runs with evidence-driven root-cause hypotheses, validation steps, and safe remediations.
+argument-hint: "<flow-name-or-id> [--run-id <id>] [--time-window <hours>] [--include-history <count>] [--dry-run]"
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Write
+  - Edit
+  - AskUserQuestion
+---
+
+# Flow Debug
+
+## Purpose
+Triage flow failures quickly and generate actionable remediation guidance.
+
+## When to use
+- A cloud flow run failed or timed out.
+- Intermittent connector errors need structured diagnosis.
+- You need a post-incident summary with next actions.
+
+## Required inputs/prereqs
+- Flow identifier and failing run ID (or time window to locate failures).
+- Access to run history and action-level error payloads.
+- Relevant connector ownership/auth context.
+- Optional recent run sample count for trend analysis.
+
+## Step-by-step execution procedure
+1. Locate failed run(s) and capture failing action metadata.
+2. Classify error type (auth, throttling, payload, dependency, logic).
+3. Build ranked root-cause hypotheses with direct evidence.
+4. Propose validation checks for each hypothesis.
+5. Provide low-risk remediations and rollback/guardrail notes.
+6. Summarize prevention improvements (retries, dead-lettering, alerting).
+
+**Concrete example invocation**
+```text
+/flow-debug 4f6f0a2b-aaaa-bbbb-cccc-1234567890ab --run-id 08586420100234567890123456789CU12 --include-history 10
+```
+
+**Failure-mode example**
+```text
+/flow-debug
+```
+Expected assistant behavior: reject empty invocation and request at minimum a flow name or ID.
+
+## Output schema/format expected from the assistant
+Return in this order:
+1. `IncidentSummary` (`Flow`, `RunId`, `FailureStage`, `Impact`).
+2. `Hypotheses` table: `Rank`, `Hypothesis`, `Evidence`, `ValidationStep`, `Confidence`.
+3. `RemediationPlan` table: `Action`, `Risk`, `Rollback`, `Owner`.
+4. `PreventionBacklog` bullets.
+
+## Validation checklist
+- Command name is `flow-debug` and matches file name.
+- At least one failing run is identified.
+- Hypotheses are evidence-backed and ranked.
+- Each remediation includes risk and rollback note.
+- Output includes incident summary, hypotheses, remediation plan, and prevention backlog.

--- a/power-automate/commands/flow-deploy-check.md
+++ b/power-automate/commands/flow-deploy-check.md
@@ -1,2 +1,62 @@
-Run a deployment readiness checklist for a flow:
-connection references, environment variables, owner model, and rollback plan.
+---
+name: flow-deploy-check
+description: Run a deployment readiness review for a Power Automate flow, including connection references, variables, ownership, and rollback posture.
+argument-hint: "<flow-name-or-id> [--source-env <name>] [--target-env <name>] [--solution <name>] [--strict]"
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Write
+  - Edit
+  - AskUserQuestion
+---
+
+# Flow Deploy Check
+
+## Purpose
+Validate that a flow is safe to promote between environments.
+
+## When to use
+- Before moving a flow from dev/test to production.
+- During release gates where deployment blockers must be explicit.
+- After connector or owner changes that may affect runtime behavior.
+
+## Required inputs/prereqs
+- Flow ID/name and source/target environments.
+- Solution context (if solution-aware deployment is used).
+- Connection references and environment variable mappings.
+- Rollback strategy and release owner.
+
+## Step-by-step execution procedure
+1. Confirm source and target environment context.
+2. Validate all connection references resolve in target.
+3. Validate environment variables and secrets are mapped.
+4. Check owner/service account model and least-privilege posture.
+5. Review dependency list (child flows, custom connectors, Dataverse tables).
+6. Score readiness and list blockers with remediation owners.
+
+**Concrete example invocation**
+```text
+/flow-deploy-check purchase-approval-flow --source-env dev --target-env prod --solution ContosoProcurement --strict
+```
+
+**Failure-mode example**
+```text
+/flow-deploy-check purchase-approval-flow --source-env dev
+```
+Expected assistant behavior: report missing `--target-env`, mark check as incomplete, and provide exact rerun command.
+
+## Output schema/format expected from the assistant
+Return in this order:
+1. `ReadinessScore` (`pass|conditional|fail`) with numeric score.
+2. `Checks` table: `Check`, `Status`, `Evidence`, `Severity`.
+3. `Blockers` table: `Blocker`, `Owner`, `Fix`, `ETA`.
+4. `GoNoGoRecommendation` short paragraph.
+
+## Validation checklist
+- Command name is `flow-deploy-check` and matches file name.
+- Source and target environments are both provided.
+- Connection/environment variable checks are explicit.
+- Output contains severity-based blockers.
+- Recommendation aligns with readiness score.

--- a/power-automate/commands/flow-design.md
+++ b/power-automate/commands/flow-design.md
@@ -1,2 +1,61 @@
-Design a Power Automate flow structure with clear trigger, actions,
-branching, and retry strategy. Emphasize maintainability.
+---
+name: flow-design
+description: Design a maintainable Power Automate cloud flow with trigger, actions, control paths, retries, and idempotency guidance.
+argument-hint: "<business-goal> [--trigger <type>] [--systems <graph,sharepoint,dataverse,...>] [--sla <minutes>] [--volume <low|medium|high>]"
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Write
+  - Edit
+  - AskUserQuestion
+---
+
+# Flow Design
+
+## Purpose
+Produce a deterministic blueprint for a Power Automate flow before implementation.
+
+## When to use
+- You are creating a new flow and want production-safe structure.
+- Existing automation needs redesign for reliability or readability.
+- You need review-ready design artifacts for approval.
+
+## Required inputs/prereqs
+- Clear business goal and success criteria.
+- Trigger type and source systems/connectors.
+- Throughput expectation and SLA/latency target.
+- Identity/connection constraints (service account, connection references).
+
+## Step-by-step execution procedure
+1. Capture objective, trigger, and data contracts.
+2. Define flow stages (`ingest`, `validate`, `process`, `notify`, `log`).
+3. Add branching and exception paths with explicit conditions.
+4. Define retries, timeout behavior, and idempotency key strategy.
+5. Specify observability (run history fields, correlation ID, alerting).
+6. Return implementation checklist and testing scenarios.
+
+**Concrete example invocation**
+```text
+/flow-design "Create an approval flow for high-value purchase requests" --trigger manual --systems sharepoint,teams,outlook --sla 15 --volume medium
+```
+
+**Failure-mode example**
+```text
+/flow-design "Sync opportunities" --systems dataverse,sap
+```
+Expected assistant behavior: request missing trigger details and expected sync cadence before producing design.
+
+## Output schema/format expected from the assistant
+Return in this order:
+1. `FlowBlueprint` with sections: `Trigger`, `MainPath`, `Branches`, `FailurePath`, `RetryPolicy`, `Idempotency`.
+2. `ConnectorMatrix` table: `Connector`, `Purpose`, `AuthModel`, `KnownLimits`.
+3. `TestPlan` list: happy path, transient failure, permanent failure, duplicate event.
+
+## Validation checklist
+- Command name is `flow-design` and matches file name.
+- Trigger and cadence are explicit.
+- Retry and idempotency strategy are documented.
+- Failure path includes alerting and operator action.
+- Output includes blueprint, connector matrix, and test plan.


### PR DESCRIPTION
### Motivation
- Ensure command documentation is consistent, deterministic, and Codex-friendly across Azure cost, Power Automate, and policy/security plugins.
- Align command docs with repository standards that require explicit frontmatter and a predictable section order for automated validation and reviewer agents.
- Improve promptability and reduce ambiguity by specifying expected assistant output schemas and concrete/failure examples per command.

### Description
- Added full frontmatter (`name`, `description`, `argument-hint`, `allowed-tools`) to all non-setup commands under `azure-cost-governance/commands`, `power-automate/commands`, and `azure-policy-security/commands`.
- Rewrote each targeted command to include the ordered sections: `Purpose`, `When to use`, `Required inputs/prereqs`, `Step-by-step execution procedure`, `Output schema/format expected from the assistant`, and `Validation checklist`.
- Included at least one concrete invocation and one failure-mode example in every updated command and ensured command names match filenames and README listings.
- Added deterministic output schemas and validation checklists to make responses machine-consumable and easier for automated reviewers to verify.

### Testing
- Ran a pattern-based validation using `rg` to confirm presence of frontmatter keys and required headings across the updated files, and all checks passed.
- Verified each targeted file contains both a concrete example and a failure-mode example using the same `rg`-based scan, and all files matched the required patterns.
- Confirmed only the intended non-setup command files under the three plugin directories were updated by inspecting the modified file list and reviewing diffs for each target file; no setup command docs were changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4b83fd3a4832a849d1862a8ab05e9)