### PR TITLE
Add YAML frontmatter to setup command docs and enforce frontmatter validation

### DIFF
--- a/azure-cost-governance/commands/setup.md
+++ b/azure-cost-governance/commands/setup.md
@@ -1,6 +1,22 @@
+---
+name: setup
+description: Prepare Azure cost governance analysis by confirming scope, timeframe, dimensions, and an execution plan.
+argument-hint: "[--scope <subscription|management-group|tenant>] [--period <last-30-days|last-90-days|custom>] [--currency <code>] [--dimensions <service,resource-group,tag,...>]"
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Write
+  - Edit
+  - AskUserQuestion
+---
+
+# Setup
+
 Use this command before cost analysis tasks.
 
-1. Confirm billing scope (subscription, MG, or tenant).
-2. Confirm target period (e.g., last 30/90 days).
+1. Confirm billing scope (subscription, management group, or tenant).
+2. Confirm target period (for example: last 30/90 days).
 3. Confirm currency and cost dimensions (service, resource group, tag).
 4. Produce a short plan before running optimization actions.

--- a/azure-policy-security/commands/setup.md
+++ b/azure-policy-security/commands/setup.md
@@ -1,3 +1,19 @@
+---
+name: setup
+description: Prepare Azure policy and security posture analysis by confirming scope, baseline initiatives, severity model, and ownership.
+argument-hint: "[--scope <tenant|management-group|subscription>] [--baseline <cis|nist|custom>] [--severity-model <model>] [--owners <team-or-group,...>]"
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Write
+  - Edit
+  - AskUserQuestion
+---
+
+# Setup
+
 Prepare posture analysis:
 1. Confirm scope (tenant, management group, subscriptions).
 2. Confirm baseline policy initiatives.

--- a/package.json
+++ b/package.json
@@ -13,8 +13,9 @@
     "test:coverage": "jest --coverage",
     "lint": "tsc --noEmit",
     "validate:marketplace": "node scripts/validate-marketplace.mjs",
-    "validate:all": "npm run validate:marketplace && npm run validate:plugins",
-    "validate:plugins": "node scripts/validate-plugins.mjs"
+    "validate:all": "npm run validate:marketplace && npm run validate:plugins && npm run validate:command-frontmatter",
+    "validate:plugins": "node scripts/validate-plugins.mjs",
+    "validate:command-frontmatter": "node scripts/validate-command-frontmatter.mjs"
   },
   "repository": {
     "type": "git",

--- a/power-automate/commands/setup.md
+++ b/power-automate/commands/setup.md
@@ -1,3 +1,19 @@
+---
+name: setup
+description: Prepare Power Automate flow work by confirming environment boundaries, connectors, scale expectations, and failure handling.
+argument-hint: "[--environment <name>] [--solution <name>] [--connectors <connector,...>] [--trigger-volume <low|medium|high>] [--sla <minutes>]"
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Write
+  - Edit
+  - AskUserQuestion
+---
+
+# Setup
+
 Prepare for flow work:
 1. Identify environment and solution boundaries.
 2. Identify connectors and auth requirements.

--- a/scripts/validate-command-frontmatter.mjs
+++ b/scripts/validate-command-frontmatter.mjs
@@ -1,0 +1,42 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const rootDir = process.cwd();
+const rootEntries = fs.readdirSync(rootDir, { withFileTypes: true });
+const commandFiles = [];
+
+for (const entry of rootEntries) {
+  if (!entry.isDirectory() || entry.name.startsWith('.')) {
+    continue;
+  }
+
+  const commandsDir = path.join(rootDir, entry.name, 'commands');
+  if (!fs.existsSync(commandsDir) || !fs.statSync(commandsDir).isDirectory()) {
+    continue;
+  }
+
+  const files = fs.readdirSync(commandsDir, { withFileTypes: true });
+  for (const file of files) {
+    if (file.isFile() && file.name.endsWith('.md')) {
+      commandFiles.push(path.join(entry.name, 'commands', file.name));
+    }
+  }
+}
+
+let hasError = false;
+
+for (const relativePath of commandFiles.sort()) {
+  const absolutePath = path.join(rootDir, relativePath);
+  const content = fs.readFileSync(absolutePath, 'utf8');
+
+  if (!content.startsWith('---\n')) {
+    hasError = true;
+    console.error(`Missing leading YAML frontmatter delimiter in ${relativePath}`);
+  }
+}
+
+if (hasError) {
+  process.exit(1);
+}
+
+console.log(`Command frontmatter validation passed for ${commandFiles.length} files.`);


### PR DESCRIPTION
### Motivation
- Ensure all `*/commands/*.md` files follow a canonical frontmatter contract (`name`, `description`, `argument-hint`, `allowed-tools`) so command metadata is consistent and machine-parseable.

### Description
- Added leading YAML frontmatter to the setup command docs at `azure-cost-governance/commands/setup.md`, `power-automate/commands/setup.md`, and `azure-policy-security/commands/setup.md` following the canonical contract.
- Added `scripts/validate-command-frontmatter.mjs` which scans all `*/commands/*.md` files and fails if a file does not start with the leading `---` YAML delimiter.
- Updated `package.json` to add a `validate:command-frontmatter` script and to include it in `validate:all`.
- Small wording normalization in the cost setup doc for clearer terminology (for example replacing `MG` with `management group`).

### Testing
- `node scripts/validate-command-frontmatter.mjs` passed and reported validation for 121 command files.
- `npm run validate:plugins` (plugin manifest validation) passed.
- `npm run validate:command-frontmatter` passed.
- `npm run validate:all` failed due to an unrelated existing marketplace schema issue (`/plugins/*/source must be string`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4b981c8f8832a8df536ca2448cc97)