### PR TITLE
Enhance SKILL docs for azure-cost-governance, power-automate, and azure-policy-security

### DIFF
--- a/azure-cost-governance/skills/azure-cost-governance/SKILL.md
+++ b/azure-cost-governance/skills/azure-cost-governance/SKILL.md
@@ -1,6 +1,48 @@
 # Azure Cost Governance Skill
 
-Provide practical FinOps guidance:
-- prioritize high-confidence savings opportunities
-- show business impact (monthly and annualized)
-- include risk/rollback notes for every recommendation
+## Purpose
+Provide practical FinOps guidance with high-confidence savings actions, business impact (monthly + annualized), and explicit rollback risk notes.
+
+## Trigger phrases (natural prompts → command)
+Use these mappings to route user requests predictably:
+- "show Azure spend by resource group/service/tag" → `azure-cost-query`
+- "build a cost query for last 30 days" → `azure-cost-query`
+- "check budget overrun risk this month" → `azure-budget-check`
+- "forecast whether we will exceed budget" → `azure-budget-check`
+- "find idle Azure resources and savings" → `azure-idle-resources`
+- "identify shutdown/deallocation candidates" → `azure-idle-resources`
+- "set up cost governance context first" → `setup`
+
+## Prerequisites
+- Tenant role: reader-level visibility to billing/cost data for target scope; contributor/owner only if user asks for execution actions.
+- Permissions: access to Cost Management data and budgets at subscription/management group/tenant billing scope.
+- Subscription scope: explicit scope path is required (for example `/subscriptions/<id>`).
+- Tooling: Azure CLI authenticated (`az login`) and access to cost/budget telemetry sources used by this plugin.
+- Governance context: timeframe, currency, and analysis dimensions agreed before running optimization recommendations.
+
+## Expected inputs
+- `scope`: subscription, resource group, or management group path.
+- `timeframe`: preset (`MTD`, `QTD`, `last-30-days`, etc.) or explicit `start/end` dates.
+- `focus`: budget health, spend breakdown, or idle-resource optimization objective.
+- Optional constraints: resource types, savings floor, alert thresholds, forecast horizon.
+
+## Promised output structure
+Always return deterministic, command-aligned sections:
+1. Short executive summary (3-6 bullets).
+2. Primary result table/JSON schema required by selected command.
+3. Prioritized actions with estimated savings range and owner suggestion.
+4. Assumptions, telemetry gaps, and confidence/risk notes.
+
+## Decision tree (which command to run)
+1. Need to initialize scope/timeframe/currency/dimensions before analysis? → `setup`
+2. Need spend breakdowns, groupings, filters, or reproducible query JSON? → `azure-cost-query`
+3. Need budget utilization + forecast breach risk + interventions? → `azure-budget-check`
+4. Need underutilization detection and reversible optimization actions? → `azure-idle-resources`
+5. Request combines multiple goals? Run in order: `setup` → `azure-cost-query`/`azure-budget-check` → `azure-idle-resources` as needed.
+
+## Minimal references
+- `azure-cost-governance/commands/setup.md`
+- `azure-cost-governance/commands/azure-cost-query.md`
+- `azure-cost-governance/commands/azure-budget-check.md`
+- `azure-cost-governance/commands/azure-idle-resources.md`
+- `azure-cost-governance/README.md`

--- a/azure-policy-security/skills/azure-policy-security/SKILL.md
+++ b/azure-policy-security/skills/azure-policy-security/SKILL.md
@@ -1,6 +1,46 @@
 # Azure Policy & Security Skill
 
-When reporting posture:
-- focus on actionable remediations
-- include blast-radius and urgency
-- separate quick wins from structural fixes
+## Purpose
+Report Azure governance posture with actionable remediations, explicit blast radius/urgency, and separation of quick wins vs structural fixes.
+
+## Trigger phrases (natural prompts → command)
+- "measure policy coverage against CIS/NIST" → `policy-coverage`
+- "show policy guardrail gaps by category" → `policy-coverage`
+- "find compliance drift since last month" → `drift-analysis`
+- "analyze policy regressions and aging exemptions" → `drift-analysis`
+- "turn findings into an execution plan" → `remediation-plan`
+- "build remediation waves with owners and due dates" → `remediation-plan`
+- "set baseline, scope, and ownership model first" → `setup`
+
+## Prerequisites
+- Tenant role: security reader/policy insights reader for assessment; policy contributor/owner only when asked to implement changes.
+- Permissions: read access to policy definitions, initiatives, assignments, compliance states, and exemption metadata.
+- Subscription scope: explicit management group/subscription/resource group scope path.
+- Tooling: authenticated Azure context (`az login`) with policy insight visibility.
+- Governance prerequisites: selected baseline (`cis`, `nist`, or documented custom), severity model, and remediation owner mapping.
+
+## Expected inputs
+- `scope`: management group/subscription/resource group.
+- `baseline`: control framework or named baseline.
+- `time boundary`: `since` date for drift analysis when requested.
+- Optional execution constraints: owners mapping, remediation window, max parallel work.
+
+## Promised output structure
+1. Posture summary with explicit coverage/drift metrics.
+2. Prioritized findings tables (severity + evidence + scope).
+3. Sequenced remediation actions with owners, success criteria, and timeline cues.
+4. Assumptions/exemptions notes and verification guidance.
+
+## Decision tree (which command to run)
+1. Need to establish scope, baseline, severity model, or ownership before analysis? → `setup`
+2. Need baseline adherence/guardrail completeness metrics? → `policy-coverage`
+3. Need changes/regressions over time, including exemption aging? → `drift-analysis`
+4. Need execution roadmap from existing coverage/drift findings? → `remediation-plan`
+5. Full posture-to-execution workflow? Run in order: `setup` → `policy-coverage` and/or `drift-analysis` → `remediation-plan`.
+
+## Minimal references
+- `azure-policy-security/commands/setup.md`
+- `azure-policy-security/commands/policy-coverage.md`
+- `azure-policy-security/commands/drift-analysis.md`
+- `azure-policy-security/commands/remediation-plan.md`
+- `azure-policy-security/README.md`

--- a/power-automate/skills/power-automate/SKILL.md
+++ b/power-automate/skills/power-automate/SKILL.md
@@ -1,6 +1,46 @@
 # Power Automate Skill
 
-When generating or reviewing flows:
-- use idempotent patterns where possible
-- minimize connector sprawl
-- include explicit error branches and alerts
+## Purpose
+Design, troubleshoot, and release cloud flows with idempotent patterns, minimal connector sprawl, and explicit error handling.
+
+## Trigger phrases (natural prompts → command)
+- "help me design a new cloud flow" → `flow-design`
+- "draft a reliable approval flow" → `flow-design`
+- "debug failed flow run" / "why did this run fail" → `flow-debug`
+- "triage intermittent connector errors" → `flow-debug`
+- "is this flow ready for prod deployment" → `flow-deploy-check`
+- "run release gate checks for this flow" → `flow-deploy-check`
+- "set environment/connectors/SLA context first" → `setup`
+
+## Prerequisites
+- Tenant role: environment maker or equivalent flow author role; admin role required for cross-environment diagnostics/deployment governance.
+- Permissions: access to target flow run history, connectors used by the flow, and source/target environments.
+- Subscription/environment scope: explicit Power Platform environment and (if used) solution boundary.
+- Tooling: authenticated access to Power Automate admin/runtime surfaces and connector metadata.
+- Operational context: defined SLA, trigger volume, owner/on-call model, and rollback expectations.
+
+## Expected inputs
+- `flow-name-or-id` or business goal (for new design).
+- Environment context: source/target environment, solution name (if solution-aware).
+- Runtime context: failing run ID or time window for diagnostics.
+- Non-functional constraints: SLA, throughput volume, compliance/approval constraints.
+
+## Promised output structure
+1. Clear command-specific artifact (blueprint, incident analysis, or readiness report).
+2. Evidence-backed tables with status/severity/confidence.
+3. Actionable remediation or deployment recommendations with owner and rollback notes.
+4. Preventive improvements and validation checks.
+
+## Decision tree (which command to run)
+1. Need to capture environment boundaries, connectors, SLA, and failure expectations first? → `setup`
+2. Need architecture for a new/refactored flow (trigger, branches, retries, idempotency)? → `flow-design`
+3. Need root-cause hypotheses for failed/timed-out/intermittent runs? → `flow-debug`
+4. Need go/no-go readiness before promoting flow across environments? → `flow-deploy-check`
+5. End-to-end request? Run in order: `setup` → `flow-design` → `flow-deploy-check`; use `flow-debug` whenever incident evidence is present.
+
+## Minimal references
+- `power-automate/commands/setup.md`
+- `power-automate/commands/flow-design.md`
+- `power-automate/commands/flow-debug.md`
+- `power-automate/commands/flow-deploy-check.md`
+- `power-automate/README.md`


### PR DESCRIPTION
### Motivation
- Clarify how natural-language prompts map to existing command documents and make skill routing deterministic.
- Ensure each skill documents prerequisites, expected inputs, and a stable output contract so agents and reviewers can invoke commands reliably.
- Provide a simple decision tree so callers know which `commands/` entry to run for common workflows.

### Description
- Added Trigger phrases, Prerequisites, Expected inputs, Promised output structure, Decision tree, and Minimal references to `azure-cost-governance/skills/azure-cost-governance/SKILL.md`.
- Added Trigger phrases, Prerequisites, Expected inputs, Promised output structure, Decision tree, and Minimal references to `power-automate/skills/power-automate/SKILL.md`.
- Added Trigger phrases, Prerequisites, Expected inputs, Promised output structure, Decision tree, and Minimal references to `azure-policy-security/skills/azure-policy-security/SKILL.md`.
- These are documentation-only changes that align the SKILL docs with the existing `commands/` artifacts and restrict references to the essential files listed in each skill.

### Testing
- Verified presence of required sections in each updated SKILL doc with the check `rg -n "^## (Trigger phrases|Prerequisites|Expected inputs|Promised output structure|Decision tree|Minimal references)"` which succeeded for all three files.
- Ran the full repository validation with `npm run validate:all`, which failed due to existing marketplace schema errors (`/plugins/*/source must be string`) unrelated to these documentation edits.
- No command or runtime code was changed, and the documentation updates are deterministic and consistent with existing `commands/` definitions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4ba1f80ac832abdcf28ac5f52645d)