### PR TITLE
Add docs-quality Jest guardrail tests for marketplace plugins

### DIFF
--- a/tests/docs-quality.test.ts
+++ b/tests/docs-quality.test.ts
@@ -1,0 +1,159 @@
+import fs from "node:fs";
+import path from "node:path";
+
+type MarketplacePlugin = {
+  name: string;
+  source: string | { source: string; [key: string]: unknown };
+};
+
+const repoRoot = path.resolve(__dirname, "..");
+const marketplacePath = path.join(repoRoot, ".claude-plugin", "marketplace.json");
+const claudeDocPath = path.join(repoRoot, "CLAUDE.md");
+
+function readJson<T>(filePath: string): T {
+  return JSON.parse(fs.readFileSync(filePath, "utf8")) as T;
+}
+
+function getLocalMarketplacePlugins(): Array<MarketplacePlugin & { source: string }> {
+  const marketplace = readJson<{ plugins: MarketplacePlugin[] }>(marketplacePath);
+  return marketplace.plugins.filter(
+    (plugin): plugin is MarketplacePlugin & { source: string } =>
+      typeof plugin.source === "string" && plugin.source.startsWith("./")
+  );
+}
+
+function getMarkdownFilesInDir(dirPath: string): string[] {
+  if (!fs.existsSync(dirPath) || !fs.statSync(dirPath).isDirectory()) {
+    return [];
+  }
+
+  return fs
+    .readdirSync(dirPath, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".md"))
+    .map((entry) => path.join(dirPath, entry.name));
+}
+
+function parseClaudePluginTableSlugs(): Set<string> {
+  const content = fs.readFileSync(claudeDocPath, "utf8");
+  const slugs = new Set<string>();
+
+  const rowRegex = /^\|\s*`([^`]+)`\s*\|/gm;
+  let match: RegExpExecArray | null = null;
+  while ((match = rowRegex.exec(content)) !== null) {
+    slugs.add(match[1]);
+  }
+
+  return slugs;
+}
+
+function hasFrontmatter(content: string): boolean {
+  return /^---\n[\s\S]*?\n---\n/.test(content);
+}
+
+function getFrontmatter(content: string): string {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n/);
+  return match ? match[1] : "";
+}
+
+describe("Documentation quality guardrails", () => {
+  const localPlugins = getLocalMarketplacePlugins();
+
+  test("local marketplace plugins have matching directory and README", () => {
+    expect(localPlugins.length).toBeGreaterThan(0);
+
+    for (const plugin of localPlugins) {
+      const directoryName = plugin.source.replace(/^\.\//, "");
+      const pluginDir = path.join(repoRoot, directoryName);
+
+      expect(directoryName).toBe(plugin.name);
+      expect(fs.existsSync(pluginDir)).toBe(true);
+      expect(fs.statSync(pluginDir).isDirectory()).toBe(true);
+      expect(fs.existsSync(path.join(pluginDir, "README.md"))).toBe(true);
+    }
+  });
+
+  test("command files include frontmatter and minimum required sections", () => {
+    const commandFiles: string[] = [];
+
+    for (const plugin of localPlugins) {
+      const pluginDir = path.join(repoRoot, plugin.source.replace(/^\.\//, ""));
+      commandFiles.push(...getMarkdownFilesInDir(path.join(pluginDir, "commands")));
+    }
+
+    expect(commandFiles.length).toBeGreaterThan(0);
+
+    for (const filePath of commandFiles) {
+      const content = fs.readFileSync(filePath, "utf8");
+
+      expect(hasFrontmatter(content)).toBe(true);
+      expect(content).toMatch(/^#\s+.+/m); // title section
+      const hasSecondarySection = /^##\s+.+/m.test(content);
+      const hasOrderedInstructionList = /^\d+\.\s+.+/m.test(content);
+      expect(hasSecondarySection || hasOrderedInstructionList).toBe(true);
+    }
+  });
+
+  test("every local plugin has at least one SKILL trigger phrase section", () => {
+    for (const plugin of localPlugins) {
+      const pluginDir = path.join(repoRoot, plugin.source.replace(/^\.\//, ""));
+      const skillsRoot = path.join(pluginDir, "skills");
+      const nestedSkillDocs = fs.existsSync(skillsRoot)
+        ? fs
+            .readdirSync(skillsRoot, { withFileTypes: true })
+            .filter((entry) => entry.isDirectory())
+            .flatMap((entry) => getMarkdownFilesInDir(path.join(skillsRoot, entry.name)))
+            .filter((file) => path.basename(file) === "SKILL.md")
+        : [];
+
+      const skillDocs = getMarkdownFilesInDir(skillsRoot).concat(nestedSkillDocs);
+
+      expect(skillDocs.length).toBeGreaterThan(0);
+
+      const hasTriggerSection = skillDocs.some((skillPath) => {
+        const content = fs.readFileSync(skillPath, "utf8");
+        const frontmatter = getFrontmatter(content);
+
+        const hasFrontmatterTriggerList = /(?:^|\n)triggers:\s*(?:\n\s*-\s+.+)+/i.test(frontmatter);
+        const hasTriggerHeading = /^##\s+(Trigger Phrases?|When to (Activate|Use))\b/im.test(content);
+
+        return hasFrontmatterTriggerList || hasTriggerHeading;
+      });
+
+      expect(hasTriggerSection).toBe(true);
+    }
+  });
+
+  test("reviewer agents include explicit output format blocks", () => {
+    for (const plugin of localPlugins) {
+      const pluginDir = path.join(repoRoot, plugin.source.replace(/^\.\//, ""));
+      const agentsDir = path.join(pluginDir, "agents");
+      const reviewerAgents = getMarkdownFilesInDir(agentsDir).filter((filePath) =>
+        /review/i.test(path.basename(filePath))
+      );
+
+      for (const reviewerPath of reviewerAgents) {
+        const content = fs.readFileSync(reviewerPath, "utf8");
+        expect(content).toMatch(/##\s+Output Format\b/i);
+        expect(content).toMatch(/##\s+Output Format\b[\s\S]*?```[\s\S]*?```/i);
+      }
+    }
+  });
+
+  test("install slugs are consistent across CLAUDE.md, marketplace.json, and plugin manifests", () => {
+    const claudeSlugs = parseClaudePluginTableSlugs();
+    const marketplace = readJson<{ plugins: MarketplacePlugin[] }>(marketplacePath);
+    const marketplaceSlugs = new Set(marketplace.plugins.map((plugin) => plugin.name));
+
+    expect(claudeSlugs).toEqual(marketplaceSlugs);
+
+    for (const plugin of localPlugins) {
+      const pluginDir = path.join(repoRoot, plugin.source.replace(/^\.\//, ""));
+      const pluginManifestPath = path.join(pluginDir, ".claude-plugin", "plugin.json");
+      const manifest = readJson<{ name: string }>(pluginManifestPath);
+
+      expect(manifest.name).toBe(plugin.name);
+      expect(claudeSlugs.has(manifest.name)).toBe(true);
+      expect(marketplaceSlugs.has(manifest.name)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
### Motivation
- Add automatic, filesystem-only checks to enforce marketplace documentation and metadata consistency for local plugins.
- Catch missing command frontmatter, absent SKILL trigger phrases, reviewer agents without explicit output-format blocks, and install-slug mismatches early in CI.

### Description
- Add a new Jest module `tests/docs-quality.test.ts` that performs only filesystem checks (no network/API calls). 
- Implement checks that: verify `source: ./...` marketplace plugins have matching directories and `README.md`; ensure command `.md` files contain YAML frontmatter and a title plus either `##` sections or an ordered instruction list; confirm each plugin has at least one `SKILL.md` with a `triggers:` frontmatter list or a trigger-oriented heading; assert reviewer agent `.md` files include an `## Output Format` heading with a fenced code block; and compare install slugs parsed from `CLAUDE.md`, `.claude-plugin/marketplace.json`, and per-plugin `.claude-plugin/plugin.json` for consistency. 
- Parsing and validations use simple regex and directory traversal utilities in Node (`fs`/`path`) so the tests remain deterministic and isolated to the repo content.

### Testing
- Ran `npm test -- tests/docs-quality.test.ts` which executed the new guardrail suite. 
- Result: four checks passed and one check failed, specifically `reviewer agents include explicit output format blocks`, due to existing reviewer agent docs missing an explicit `## Output Format` fenced block. 
- Passing checks: `local marketplace plugins have matching directory and README`, `command files include frontmatter and minimum required sections`, `every local plugin has at least one SKILL trigger phrase section`, and `install slugs are consistent across CLAUDE.md, marketplace.json, and plugin manifests`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4bb2ba550832a849764630d696c6f)