### PR TITLE
Add knowledge-plugin validation and wire into `validate:all`

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
     "test:coverage": "jest --coverage",
     "lint": "tsc --noEmit",
     "validate:marketplace": "node scripts/validate-marketplace.mjs",
-    "validate:all": "npm run validate:marketplace && npm run validate:plugins && npm run validate:command-frontmatter",
+    "validate:all": "npm run validate:marketplace && npm run validate:knowledge-plugins && npm run validate:command-frontmatter",
     "validate:plugins": "node scripts/validate-plugins.mjs",
-    "validate:command-frontmatter": "node scripts/validate-command-frontmatter.mjs"
+    "validate:command-frontmatter": "node scripts/validate-command-frontmatter.mjs",
+    "validate:knowledge-plugins": "node scripts/validate-plugins.mjs"
   },
   "repository": {
     "type": "git",

--- a/scripts/validate-marketplace.mjs
+++ b/scripts/validate-marketplace.mjs
@@ -22,7 +22,20 @@ const schema = {
         additionalProperties: true,
         properties: {
           name: { type: 'string', minLength: 1 },
-          source: { type: 'string', minLength: 1 },
+          source: {
+            oneOf: [
+              { type: 'string', minLength: 1 },
+              {
+                type: 'object',
+                required: ['source', 'repo'],
+                additionalProperties: true,
+                properties: {
+                  source: { type: 'string', minLength: 1 },
+                  repo: { type: 'string', minLength: 1 }
+                }
+              }
+            ]
+          },
           description: { type: 'string', minLength: 1 },
           tags: {
             type: 'array',

--- a/scripts/validate-plugins.mjs
+++ b/scripts/validate-plugins.mjs
@@ -1,57 +1,79 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import Ajv from 'ajv';
 
-const pluginsDir = path.resolve('plugins');
-const pluginFolders = fs.readdirSync(pluginsDir, { withFileTypes: true }).filter((entry) => entry.isDirectory());
+const rootDir = process.cwd();
+const marketplacePath = path.join(rootDir, '.claude-plugin', 'marketplace.json');
+const claudeCatalogPath = path.join(rootDir, 'CLAUDE.md');
 
-const schema = {
-  type: 'object',
-  required: ['name', 'version', 'description', 'author', 'mcpServer'],
-  additionalProperties: true,
-  properties: {
-    name: { type: 'string', minLength: 1 },
-    version: { type: 'string', minLength: 1 },
-    description: { type: 'string', minLength: 1 },
-    author: { type: 'string', minLength: 1 },
-    mcpServer: {
-      type: 'object',
-      required: ['command', 'args'],
-      additionalProperties: true,
-      properties: {
-        command: { type: 'string', minLength: 1 },
-        args: {
-          type: 'array',
-          minItems: 1,
-          items: { type: 'string', minLength: 1 }
-        }
-      }
-    }
-  }
-};
+const marketplace = JSON.parse(fs.readFileSync(marketplacePath, 'utf8'));
+const claudeCatalog = parseClaudeCatalog(fs.readFileSync(claudeCatalogPath, 'utf8'));
 
-const ajv = new Ajv({ allErrors: true });
-const validate = ajv.compile(schema);
 let hasError = false;
 
-for (const folder of pluginFolders) {
-  const manifestPath = path.join(pluginsDir, folder.name, 'plugin.json');
-  if (!fs.existsSync(manifestPath)) {
-    console.error(`Missing plugin manifest: ${manifestPath}`);
-    hasError = true;
+for (const pluginEntry of marketplace.plugins ?? []) {
+  if (typeof pluginEntry.source !== 'string' || !pluginEntry.source.startsWith('./')) {
     continue;
   }
 
-  const raw = fs.readFileSync(manifestPath, 'utf8');
-  const data = JSON.parse(raw);
-  const valid = validate(data);
+  const pluginDir = path.join(rootDir, pluginEntry.source.slice(2));
+  const manifestPath = path.join(pluginDir, '.claude-plugin', 'plugin.json');
+  const readmePath = path.join(pluginDir, 'README.md');
+  const commandsDir = path.join(pluginDir, 'commands');
+  const skillsDir = path.join(pluginDir, 'skills');
 
-  if (!valid) {
-    hasError = true;
-    console.error(`Validation failed for ${manifestPath}:`);
-    for (const error of validate.errors ?? []) {
-      console.error(`- ${error.instancePath || '/'} ${error.message}`);
+  if (!fs.existsSync(pluginDir) || !fs.statSync(pluginDir).isDirectory()) {
+    fail(`Marketplace source directory does not exist: ${pluginEntry.source}`);
+    continue;
+  }
+
+  if (!fs.existsSync(manifestPath)) {
+    fail(`Missing required file ${toRepoPath(manifestPath)} for plugin ${pluginEntry.name}`);
+    continue;
+  }
+
+  if (!fs.existsSync(readmePath)) {
+    fail(`Missing required file ${toRepoPath(readmePath)} for plugin ${pluginEntry.name}`);
+  }
+
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+
+  if (!fs.existsSync(skillsDir) || !hasSkillFile(skillsDir)) {
+    fail(`Missing required skills/*/SKILL.md in ${toRepoPath(pluginDir)} for plugin ${pluginEntry.name}`);
+  }
+
+  const commandFiles = getMarkdownFiles(commandsDir);
+  if (commandFiles.length === 0) {
+    fail(`Missing required commands/*.md in ${toRepoPath(pluginDir)} for plugin ${pluginEntry.name}`);
+  }
+
+  const hasReviewerSupport = Array.isArray(manifest.agents) && manifest.agents.some((agentPath) => /reviewer/i.test(agentPath));
+  if (hasReviewerSupport) {
+    const reviewerAgentFiles = getMarkdownFiles(path.join(pluginDir, 'agents')).filter((agentPath) => /reviewer/i.test(agentPath));
+    if (reviewerAgentFiles.length === 0) {
+      fail(`Plugin ${pluginEntry.name} declares reviewer support but has no agents/*.md reviewer file`);
     }
+  }
+
+  const manifestName = manifest.name;
+  if (manifestName !== pluginEntry.name) {
+    fail(`Name mismatch for ${pluginEntry.source}: marketplace name is "${pluginEntry.name}" but manifest name is "${manifestName}"`);
+  }
+
+  const catalogEntry = claudeCatalog.get(pluginEntry.name);
+  if (!catalogEntry) {
+    fail(`Plugin ${pluginEntry.name} is missing from CLAUDE.md plugin catalog table`);
+  } else {
+    if (catalogEntry.category !== pluginEntry.category) {
+      fail(`Category drift for ${pluginEntry.name}: marketplace="${pluginEntry.category}" CLAUDE.md="${catalogEntry.category}"`);
+    }
+
+    if (!sameText(catalogEntry.description, pluginEntry.description)) {
+      fail(`Description drift for ${pluginEntry.name}: marketplace and CLAUDE.md descriptions differ`);
+    }
+  }
+
+  for (const commandPath of commandFiles) {
+    lintCommand(commandPath);
   }
 }
 
@@ -59,4 +81,117 @@ if (hasError) {
   process.exit(1);
 }
 
-console.log('Plugin manifest validation passed.');
+console.log('Knowledge plugin validation passed.');
+
+function parseClaudeCatalog(content) {
+  const catalog = new Map();
+  const lines = content.split(/\r?\n/);
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('| `') || !trimmed.endsWith('|')) {
+      continue;
+    }
+
+    const cells = trimmed
+      .slice(1, -1)
+      .split('|')
+      .map((cell) => cell.trim());
+
+    if (cells.length < 3) {
+      continue;
+    }
+
+    const slugMatch = cells[0].match(/^`([^`]+)`$/);
+    if (!slugMatch) {
+      continue;
+    }
+
+    catalog.set(slugMatch[1], {
+      category: cells[1],
+      description: cells[2]
+    });
+  }
+
+  return catalog;
+}
+
+function hasSkillFile(skillsDir) {
+  if (!fs.existsSync(skillsDir) || !fs.statSync(skillsDir).isDirectory()) {
+    return false;
+  }
+
+  const entries = fs.readdirSync(skillsDir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    const skillPath = path.join(skillsDir, entry.name, 'SKILL.md');
+    if (fs.existsSync(skillPath)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function getMarkdownFiles(directory) {
+  if (!fs.existsSync(directory) || !fs.statSync(directory).isDirectory()) {
+    return [];
+  }
+
+  return fs
+    .readdirSync(directory, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))
+    .map((entry) => path.join(directory, entry.name));
+}
+
+function lintCommand(commandPath) {
+  const content = fs.readFileSync(commandPath, 'utf8');
+
+  const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---\n/);
+  if (!frontmatterMatch) {
+    fail(`Missing YAML frontmatter block in ${toRepoPath(commandPath)}`);
+    return;
+  }
+
+  const frontmatter = frontmatterMatch[1];
+  if (!/^description:/m.test(frontmatter)) {
+    fail(`Command frontmatter missing "description" in ${toRepoPath(commandPath)}`);
+  }
+
+  if (!/^allowed-tools:/m.test(frontmatter)) {
+    fail(`Command frontmatter missing "allowed-tools" in ${toRepoPath(commandPath)}`);
+  }
+
+  const body = content.slice(frontmatterMatch[0].length);
+  if (!/^##\s+/m.test(body)) {
+    fail(`Command doc must include at least one H2 section (## ...) in ${toRepoPath(commandPath)}`);
+  }
+
+  if (!/^\d+\.\s+/m.test(body) && !/^[-*]\s+/m.test(body)) {
+    fail(`Command doc should include deterministic steps/checks as a list in ${toRepoPath(commandPath)}`);
+  }
+}
+
+function sameText(left, right) {
+  return normalize(left) === normalize(right);
+}
+
+function normalize(value) {
+  return String(value ?? '')
+    .toLowerCase()
+    .replace(/[—–]/g, '-')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+function toRepoPath(absolutePath) {
+  return path.relative(rootDir, absolutePath) || '.';
+}
+
+function fail(message) {
+  hasError = true;
+  console.error(message);
+}


### PR DESCRIPTION
### Motivation
- Ensure marketplace-local plugins (those with `source: ./...`) are validated end-to-end for required assets and docs before publishing. 
- Catch cross-file inconsistencies early by checking `CLAUDE.md`, marketplace entries, and plugin manifests together. 
- Raise the bar for command docs by enforcing frontmatter and deterministic structure so command docs are machine- and human-friendly.

### Description
- Reworked `scripts/validate-plugins.mjs` to validate local marketplace plugins referenced from `.claude-plugin/marketplace.json`, checking plugin directory existence and required files such as `.claude-plugin/plugin.json`, `README.md`, at least one `skills/*/SKILL.md`, and `commands/*.md`.
- Added reviewer-agent checks so if a plugin manifest declares reviewer support in `agents` the repository must include an agents/*.md reviewer file. 
- Added cross-file consistency checks that compare marketplace entry name/slug and category/description against the plugin manifest and the root `CLAUDE.md` catalog, including normalization-based description drift detection. 
- Implemented command doc linting to ensure each `commands/*.md` contains YAML frontmatter and required keys (`description`, `allowed-tools`) and includes deterministic structure cues (at least one `##` H2 and list-style steps/checks). 
- Updated `scripts/validate-marketplace.mjs` schema to accept either a string `source` or an object source (e.g., GitHub source objects) to match current marketplace shapes. 
- Wired the new validator into `package.json` by adding the `validate:knowledge-plugins` script and updating `validate:all` to run it (`npm run validate:marketplace && npm run validate:knowledge-plugins && npm run validate:command-frontmatter`).

### Testing
- Ran `npm run validate:marketplace` which completed successfully and printed `Marketplace schema validation passed.`. 
- Ran the combined validation via `npm run validate:all`, which now executes the new knowledge-plugin checks and reported existing repository issues (description drift and command-structure violations) causing the validation to fail as expected for current content. 
- Also ran `node scripts/validate-marketplace.mjs && node scripts/validate-plugins.mjs` to exercise both validators locally and observed the same drift/command linting findings reported above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4bd421584832a8ff2e5bbb3f3b512)