### PR TITLE
Add compact operational knowledge references for high-usage plugins

### DIFF
--- a/azure-devops/skills/azure-devops/SKILL.md
+++ b/azure-devops/skills/azure-devops/SKILL.md
@@ -277,3 +277,7 @@ ORDER BY [Microsoft.VSTS.Common.Priority] ASC, [System.CreatedDate] DESC
 | PR Automation | `examples/pr-automation.md` | Create PRs, add reviewers, auto-complete |
 | Sprint Setup | `examples/sprint-setup.md` | Create iteration paths, work items, and board configuration |
 | Artifact Publishing | `examples/artifact-publishing.md` | Publish and consume npm/NuGet packages |
+
+## Knowledge references
+
+- `references/operational-knowledge.md` — compact API surface map, prerequisite matrix, deterministic failure remediation, limits/quotas and pagination/throttling guidance, and safe-default read-first/apply-second pattern.

--- a/azure-devops/skills/azure-devops/references/operational-knowledge.md
+++ b/azure-devops/skills/azure-devops/references/operational-knowledge.md
@@ -1,0 +1,50 @@
+# Azure DevOps operational knowledge (compact)
+
+## 1) Core API / surface map
+- **Repos**: Git repositories, branches, branch policies, pull requests (`/_apis/git/*`).
+- **Pipelines**: YAML pipelines/runs/logs (`/_apis/pipelines/*`), build definitions/runs (`/_apis/build/*`).
+- **Work tracking**: Work items + WIQL queries (`/_apis/wit/*`).
+- **Artifacts**: Feeds, packages, versions (`/_apis/packaging/*`).
+- **Security/admin**: Project/team settings, service connections, variable groups, approvals/checks.
+
+## 2) Prerequisite matrix
+| Area | Minimum requirement |
+|---|---|
+| Organization/project | Existing Azure DevOps org and target project access |
+| Auth | PAT with least-required scopes or Microsoft Entra OAuth token |
+| Repo operations | Repo Contribute/Branch Create permissions |
+| PR governance | Permission to set branch policies and complete PRs |
+| Pipeline operations | Queue builds + edit pipeline permissions; agent pool access |
+| Tenant linkage | If using Entra OAuth/service connections, tenant app consent and subscription rights (for Azure deployments) |
+
+## 3) Common failure modes and deterministic remediation
+- **401/403 on REST calls**
+  1. Check PAT validity/expiry.
+  2. Verify required scopes for endpoint area.
+  3. Confirm user/service principal project permissions.
+- **Pipeline fails on service connection auth**
+  1. Revalidate service connection credentials.
+  2. Confirm subscription/resource RBAC.
+  3. Re-run with system diagnostics enabled.
+- **PR blocked unexpectedly**
+  1. Inspect branch policies (required reviewers/build/status checks).
+  2. Resolve stale comments and required checks.
+  3. Requeue validation pipeline.
+- **Work item query incomplete**
+  1. Use WIQL with explicit Area/Iteration filters.
+  2. Handle continuation/paging in result processing.
+  3. Verify security trimming is not hiding items.
+
+## 4) Limits, quotas, pagination/throttling guidance
+- **REST pagination**: use `$top` + continuation tokens for list APIs; do not assume full result in one response.
+- **Rate limits**: handle `429` with exponential backoff and retry budget.
+- **Pipeline concurrency**: bounded by agent pool capacity and parallel job entitlement.
+- **Artifact limits**: feed/package retention and size constraints require cleanup policies.
+- **Large org queries**: scope repo/work item queries by project/path/time to avoid expensive scans.
+
+## 5) Safe-default operational patterns
+1. **Read-only first**: list repos/policies/pipelines/work items before mutating state.
+2. **Dry-run changes**: draft pipeline YAML/PR policy updates in feature branch first.
+3. **Small blast radius**: apply to one project/repo/pipeline, then expand.
+4. **Require policy evidence**: keep build validation and reviewer checks enforced.
+5. **Rollback ready**: maintain prior YAML, policy snapshot, and service connection fallback.

--- a/azure-functions/skills/azure-functions/SKILL.md
+++ b/azure-functions/skills/azure-functions/SKILL.md
@@ -1432,3 +1432,7 @@ app.timer("cleanupExpiredRecords", {
     handler: cleanupExpiredRecords,
 });
 ```
+
+## Knowledge references
+
+- `references/operational-knowledge.md` — compact API surface map, prerequisite matrix, deterministic failure remediation, limits/throttling guidance, and safe-default read-first/apply-second pattern.

--- a/azure-functions/skills/azure-functions/references/operational-knowledge.md
+++ b/azure-functions/skills/azure-functions/references/operational-knowledge.md
@@ -1,0 +1,50 @@
+# Azure Functions operational knowledge (compact)
+
+## 1) Core API / surface map
+- **Runtime + app lifecycle**: `az functionapp *` (create/config/deploy/log stream), `func start`, `func azure functionapp publish`.
+- **Config and secrets**: App settings (`az functionapp config appsettings *`), Key Vault references in app settings, managed identity.
+- **Function endpoints**: HTTP triggers (`/api/<route>`), non-HTTP triggers (Storage Queue/Blob, Service Bus, Event Grid, Event Hub, Timer).
+- **Durable Functions**: `orchestrators`, `activities`, `entities`; status query endpoints for orchestration lifecycle.
+- **Observability**: Application Insights traces/requests/dependencies + Azure Monitor metrics and alerts.
+
+## 2) Prerequisite matrix
+| Area | Minimum requirement |
+|---|---|
+| Azure access | Subscription with permission to create `Microsoft.Web/sites`, Storage account, and App Insights resources |
+| RBAC (deploy) | Contributor on resource group (or narrower custom role with Function App + config write) |
+| RBAC (read-only ops) | Reader on resource group + Log Analytics/Application Insights read |
+| Local tooling | Azure CLI, Azure Functions Core Tools v4, language runtime (Node/.NET/Python/Java) |
+| Tenant/auth | Signed in to correct tenant/subscription (`az account show`, `az account set`) |
+| Network/security | Outbound access to Storage/Service Bus/Event Hub endpoints; VNet integration for private dependencies when required |
+
+## 3) Common failure modes and deterministic remediation
+- **Cold start latency spikes**
+  1. Confirm hosting plan (`az functionapp plan show`).
+  2. For latency-sensitive workloads, move to Premium or Flex with always-ready instances.
+  3. Reduce package size and startup work.
+- **Trigger not firing (Queue/Blob/Service Bus/Event Hub)**
+  1. Validate connection setting exists in app settings.
+  2. Verify identity/RBAC on backing service.
+  3. Check dead-letter/poison queues and host logs.
+- **Deployment succeeds but function missing**
+  1. Confirm build output path and runtime version compatibility.
+  2. Validate `FUNCTIONS_WORKER_RUNTIME` and extension bundle config.
+  3. Restart app and inspect startup logs.
+- **429/5xx from dependencies**
+  1. Add retry with exponential backoff and jitter.
+  2. Use queue buffering/circuit breaker for downstream instability.
+  3. Tune concurrency and batch size to avoid overload.
+
+## 4) Limits, quotas, pagination/throttling guidance
+- **Execution/time**: plan-dependent timeout and scaling behavior; verify before long-running workflows.
+- **Throughput controls**: tune host concurrency, queue batch size/prefetch, and downstream connection limits.
+- **Durable history growth**: use `continueAsNew`/state compaction for long-lived orchestrations.
+- **Pagination**: when calling Graph/REST inside functions, iterate via continuation tokens (`nextLink`/skip tokens), never assume single-page results.
+- **Throttling**: treat `429` and transient `5xx` as retryable; honor `Retry-After` headers.
+
+## 5) Safe-default operational patterns
+1. **Read-only first**: inspect current config, app settings keys, trigger health, and recent failures before changes.
+2. **Dry-run by slot/environment**: validate in non-prod slot or staging app with representative traffic.
+3. **Apply minimal change**: one setting/trigger/dependency change at a time.
+4. **Verify immediately**: run smoke test + check live logs and key metrics.
+5. **Rollback path ready**: slot swap back or redeploy last known good package.

--- a/azure-monitor/skills/azure-monitor/SKILL.md
+++ b/azure-monitor/skills/azure-monitor/SKILL.md
@@ -1407,3 +1407,7 @@ az consumption budget create \
   --category Cost \
   --notifications '{"actual_GreaterThan_80":{"enabled":true,"operator":"GreaterThan","threshold":80,"contactEmails":["ops@contoso.com"]}}'
 ```
+
+## Knowledge references
+
+- `references/operational-knowledge.md` — compact API surface map, prerequisite matrix, deterministic failure remediation, limits/quotas and pagination/throttling guidance, and safe-default read-first/apply-second pattern.

--- a/azure-monitor/skills/azure-monitor/references/operational-knowledge.md
+++ b/azure-monitor/skills/azure-monitor/references/operational-knowledge.md
@@ -1,0 +1,50 @@
+# Azure Monitor operational knowledge (compact)
+
+## 1) Core API / surface map
+- **Metrics**: Azure Monitor Metrics API (`Microsoft.Insights/metrics`) for platform and custom metrics.
+- **Logs/KQL**: Log Analytics query surface (`/query`) for workspace and resource-context queries.
+- **Alerts**: Metric alerts, scheduled query (log) alerts, action groups, alert processing rules.
+- **Diagnostic settings**: Resource-level export of logs/metrics to Log Analytics, Event Hub, or Storage.
+- **Application Insights**: request/dependency/trace telemetry, availability tests, distributed tracing.
+
+## 2) Prerequisite matrix
+| Area | Minimum requirement |
+|---|---|
+| Azure access | Subscription with target resources + Log Analytics/App Insights workspace access |
+| RBAC (configure) | Monitoring Contributor (or Contributor) on monitored resources + workspace write if creating assets |
+| RBAC (read-only) | Reader on resources + Log Analytics Reader / Monitoring Reader |
+| Tenant/subscription | Correct tenant and subscription selected before query/config changes |
+| Data plumbing | Diagnostic settings enabled where platform logs are required |
+| Alert routing | Action group targets (email/webhook/ITSM) created and reachable |
+
+## 3) Common failure modes and deterministic remediation
+- **No data in Log Analytics**
+  1. Check diagnostic settings exist and categories are enabled.
+  2. Validate destination workspace and region compatibility.
+  3. Wait ingestion delay window; rerun bounded-time query.
+- **Alert not firing**
+  1. Confirm evaluation frequency/window and threshold logic.
+  2. Verify signal source has datapoints in interval.
+  3. Check alert processing rules/suppression and action group health.
+- **KQL query timeout or high cost**
+  1. Add strict time filter early (`where TimeGenerated > ago(...)`).
+  2. Project only needed columns.
+  3. Use summarize/materialized views patterns where applicable.
+- **Missing distributed traces**
+  1. Ensure app uses Application Insights/OpenTelemetry SDK correctly.
+  2. Confirm connection string and sampling settings.
+  3. Validate operation/correlation IDs are propagated.
+
+## 4) Limits, quotas, pagination/throttling guidance
+- **Workspace limits**: ingestion/retention and commitment tier directly affect cost and query horizon.
+- **Query behavior**: large scans may be throttled or timed out; optimize filters and aggregation.
+- **Alerting scale**: many high-frequency rules can create alert storms; consolidate by severity/service.
+- **Pagination**: handle API continuation (`nextLink`) for list operations and large result sets.
+- **Throttling**: implement retry with exponential backoff for control-plane and query APIs; respect service retry hints.
+
+## 5) Safe-default operational patterns
+1. **Observe before act**: baseline current metrics/log volume and existing alert inventory.
+2. **Start read-only**: run KQL diagnostics and metrics review before creating/changing alerts.
+3. **Deploy in stages**: create rules in lower environments or disabled state first, then enable.
+4. **Noise control first**: tune thresholds, dimensions, and suppression before paging on-call.
+5. **Post-change validation**: simulate signal, confirm alert fired, and verify action group delivery.

--- a/entra-id-security/skills/entra-security/SKILL.md
+++ b/entra-id-security/skills/entra-security/SKILL.md
@@ -229,3 +229,7 @@ Most of these require **application permissions** with admin consent for automat
 | CA Policy Suite | `examples/ca-policy-suite.md` | Common conditional access policy configurations |
 | Sign-In Audit | `examples/signin-audit.md` | Analyze failed sign-ins and detect anomalies |
 | Permission Audit | `examples/permission-audit.md` | Find and revoke over-permissioned OAuth grants |
+
+## Knowledge references
+
+- `references/operational-knowledge.md` — compact API surface map, prerequisite matrix, deterministic failure remediation, limits/quotas and pagination/throttling guidance, and safe-default read-first/apply-second pattern.

--- a/entra-id-security/skills/entra-security/references/operational-knowledge.md
+++ b/entra-id-security/skills/entra-security/references/operational-knowledge.md
@@ -1,0 +1,50 @@
+# Entra ID Security operational knowledge (compact)
+
+## 1) Core API / surface map
+- **App identity**: app registrations + service principals (`/applications`, `/servicePrincipals`).
+- **Conditional Access**: policies and named locations (`/identity/conditionalAccess/*`).
+- **Identity protection**: risky users and risk detections (`/identityProtection/*`).
+- **Auth telemetry**: sign-in logs and directory audits (`/auditLogs/signIns`, `/auditLogs/directoryAudits`).
+- **Consent governance**: OAuth2 permission grants and app role assignments.
+
+## 2) Prerequisite matrix
+| Area | Minimum requirement |
+|---|---|
+| Tenant role | Security Administrator / Conditional Access Administrator for policy work |
+| Graph scopes | `Policy.Read.All`/`Policy.ReadWrite.ConditionalAccess`, `AuditLog.Read.All`, app lifecycle scopes as needed |
+| Consent model | Admin consent for app permissions in automation scenarios |
+| Licensing | Entra ID P1/P2 for Conditional Access and Identity Protection scenarios |
+| Auth posture | MFA-compliant admin account and trusted admin workstation/network |
+| Target scope | Clear include/exclude users, groups, apps, and break-glass accounts before policy changes |
+
+## 3) Common failure modes and deterministic remediation
+- **CA policy lockout risk**
+  1. Start in report-only mode.
+  2. Exclude emergency access accounts.
+  3. Review sign-in impact, then enforce.
+- **403 on Graph security endpoint**
+  1. Verify role assignment and scope grant.
+  2. Confirm admin consent completed.
+  3. Re-authenticate token with updated claims.
+- **Riskiest users not visible**
+  1. Confirm required license tier.
+  2. Validate scope (`IdentityRiskyUser.Read.All` or write variant).
+  3. Query bounded time range and paginate fully.
+- **Over-privileged service principal findings**
+  1. Enumerate app role assignments.
+  2. Remove non-required grants in staged changes.
+  3. Re-test dependent workload before finalizing.
+
+## 4) Limits, quotas, pagination/throttling guidance
+- **Graph pagination**: always follow `@odata.nextLink` for sign-ins, audits, principals, and risk objects.
+- **Throttling**: identity and audit endpoints can return `429`; back off and honor retry headers.
+- **Policy complexity**: too many overlapping CA policies increases troubleshooting cost; consolidate where possible.
+- **Log horizons**: retention varies by SKU/licensing; export needed logs for long-term forensics.
+- **Write cadence**: serialize high-impact policy changes; avoid concurrent broad CA edits.
+
+## 5) Safe-default operational patterns
+1. **Read-only baseline**: export current policies, app permissions, and risky-user/sign-in trends.
+2. **Report-only first**: deploy/modify CA in report-only, validate impact with logs.
+3. **Least privilege**: grant minimum API permissions and privileged roles.
+4. **Phased enforcement**: pilot with small target groups before tenant-wide enablement.
+5. **Recovery ready**: maintain emergency access accounts and rollback instructions per policy.

--- a/m365-admin/skills/m365-admin/SKILL.md
+++ b/m365-admin/skills/m365-admin/SKILL.md
@@ -371,3 +371,7 @@ Every operation produces a structured markdown report containing:
 | License Management | `examples/license-management.md` | Assign, revoke, reassign with SKU handling |
 | Exchange Operations | `examples/exchange-operations.md` | Mailbox management, DLs, rules, calendar |
 | SharePoint Operations | `examples/sharepoint-operations.md` | Site CRUD, permissions, sharing, hubs |
+
+## Knowledge references
+
+- `references/operational-knowledge.md` — compact API surface map, prerequisite matrix, deterministic failure remediation, limits/quotas and pagination/throttling guidance, and safe-default read-first/apply-second pattern.

--- a/m365-admin/skills/m365-admin/references/operational-knowledge.md
+++ b/m365-admin/skills/m365-admin/references/operational-knowledge.md
@@ -1,0 +1,50 @@
+# M365 Admin operational knowledge (compact)
+
+## 1) Core API / surface map
+- **Users/groups/licenses**: Microsoft Graph `users`, `groups`, `subscribedSkus`, `licenseDetails`.
+- **Exchange admin surfaces**: mailbox settings, mail flow artifacts, shared mailbox/group operations (Graph + Exchange admin cmdlets where required).
+- **SharePoint admin surfaces**: site collections, sharing settings, permission posture via Graph/SharePoint admin endpoints.
+- **Audit/compliance**: sign-ins, directory audit logs, and admin activity evidence.
+- **Bulk admin workflows**: CSV-driven onboarding/offboarding/license reassignment with idempotent checkpoints.
+
+## 2) Prerequisite matrix
+| Area | Minimum requirement |
+|---|---|
+| Tenant role | At least User Administrator for user lifecycle; higher roles for license/security/policy changes |
+| Graph permissions | Delegated/app scopes aligned to operation (e.g., `User.ReadWrite.All`, `Group.ReadWrite.All`, `Directory.Read.All`) |
+| Exchange/SharePoint admin | Exchange Administrator / SharePoint Administrator role for service-specific operations |
+| Licensing | Available SKU capacity before assignment |
+| Auth context | Correct tenant and admin account with MFA/conditional access satisfied |
+| Automation | Admin consent granted for app-only flows where used |
+
+## 3) Common failure modes and deterministic remediation
+- **Insufficient privileges**
+  1. Capture exact Graph/PowerShell error.
+  2. Map to missing role/scope.
+  3. Assign minimal required role, re-consent if app permissions changed.
+- **License assignment fails**
+  1. Check `subscribedSkus` available units.
+  2. Verify conflicting service plans.
+  3. Retry assignment after dependency fixes.
+- **Group/site propagation delay**
+  1. Confirm create request succeeded.
+  2. Wait for directory replication window.
+  3. Re-query by stable object ID rather than display name.
+- **Bulk job partial failure**
+  1. Continue from failed subset only.
+  2. Use idempotent keys (UPN/objectId).
+  3. Emit per-record error report and deterministic retry file.
+
+## 4) Limits, quotas, pagination/throttling guidance
+- **Graph paging**: follow `@odata.nextLink` for all list operations.
+- **Batch constraints**: keep Graph `$batch` requests within documented request count/size limits.
+- **Throttling**: handle `429/503`, honor `Retry-After`, and avoid tenant-wide burst writes.
+- **Service limits**: license counts, group limits, mailbox/site quotas vary by SKU; verify before large changes.
+- **Audit retrieval**: bound time ranges and filter narrowly for predictable query runtime.
+
+## 5) Safe-default operational patterns
+1. **Read-only assessment first**: inventory users, groups, SKU capacity, and policy constraints.
+2. **Preview/dry-run output**: show intended adds/removes before execution.
+3. **Apply in batches**: start with pilot cohort, then full rollout.
+4. **Verify post-change**: re-read effective state (license details, mailbox/site access, group membership).
+5. **Reversible execution**: maintain rollback artifacts (previous group/license snapshot).


### PR DESCRIPTION
### Motivation
- Provide a compact, consistent operational knowledge reference for high-usage plugins to make troubleshooting and safe operations deterministic and discoverable.
- Capture core API surface, prerequisites (roles/scopes/tenant requirements), common failure modes with remediation, limits/pagination/throttling guidance, and safe-default patterns for operators.

### Description
- Added `references/operational-knowledge.md` to the following skills: `azure-functions`, `azure-monitor`, `azure-devops`, `m365-admin`, and `entra-id-security` (paths under each plugin's `skills/*/references/`).
- Updated each plugin `SKILL.md` to include a `## Knowledge references` section that links to `references/operational-knowledge.md` so the compact guide is discoverable from the skill.
- Changes are documentation-only and do not modify runtime code, installation slugs, or marketplace metadata.

### Testing
- Verified each new file exists at the expected path using shell checks like `test -f` for each `references/operational-knowledge.md` and reported success for all five plugins.
- Verified each `SKILL.md` contains the `## Knowledge references` section and the link to `references/operational-knowledge.md` using `rg`/grep checks, which all succeeded.
- Ran `git status` and committed the changes with the message `Add compact operational knowledge references for top plugins`, and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a52306c0a0832a922465e6bf478401)