### PR TITLE
Add repository-wide integration context contract and update Azure/M365 plugin docs

### DIFF
--- a/azure-cost-governance/README.md
+++ b/azure-cost-governance/README.md
@@ -8,6 +8,18 @@ Azure cost governance workflows for Claude Code teams.
 - Identify idle or underutilized resources
 - Produce optimization recommendations with expected savings
 
+## Integration Context Contract
+- Canonical contract: [`docs/integration-context.md`](../docs/integration-context.md)
+
+| Command family | tenantId | subscriptionId | environmentCloud | principalType | scopesOrRoles |
+|---|---|---|---|---|---|
+| Cost query, budgets, idle resources | required | required | `AzureCloud`\* | `delegated-user` or `service-principal` | `CostManagement.Read`, `Consumption.Read`, Azure `Reader` |
+
+\* Use sovereign cloud values from the contract when applicable.
+
+Commands must fail fast on missing/invalid context before Azure API calls and return contract error codes.
+All outputs must redact tenant/subscription identifiers using the shared policy.
+
 ## Included commands
 - `commands/setup.md`
 - `commands/azure-cost-query.md`

--- a/azure-cost-governance/commands/setup.md
+++ b/azure-cost-governance/commands/setup.md
@@ -16,6 +16,18 @@ allowed-tools:
 
 Use this command before cost analysis tasks.
 
+## Integration Context Fail-Fast Check
+
+Before any external API call, validate integration context from [`docs/integration-context.md`](../../docs/integration-context.md):
+- `tenantId` (always required)
+- `subscriptionId` (required for Azure-scope workflows)
+- `environmentCloud`
+- `principalType`
+- `scopesOrRoles`
+
+If validation fails, stop immediately and return a structured error using contract codes (`MissingIntegrationContext`, `InvalidIntegrationContext`, `ContextCloudMismatch`, `InsufficientScopesOrRoles`).
+Redact tenant/subscription/object identifiers in setup output using contract redaction rules.
+
 ## Step 1: Confirm Billing Scope
 
 Confirm the billing scope for analysis: subscription, management group, or tenant. Provide the explicit scope path (e.g., `/subscriptions/<id>` or `/providers/Microsoft.Management/managementGroups/<name>`).

--- a/azure-cost-governance/skills/azure-cost-governance/SKILL.md
+++ b/azure-cost-governance/skills/azure-cost-governance/SKILL.md
@@ -36,6 +36,17 @@ triggers:
 
 This skill provides comprehensive FinOps guidance via the Azure Cost Management and Consumption REST APIs — cost queries, budgets, forecasts, idle resource detection, and savings recommendations with risk-ranked actions and rollback notes.
 
+## Integration Context Contract
+- Canonical contract: [`docs/integration-context.md`](../../../docs/integration-context.md)
+
+| Workflow | tenantId | subscriptionId | environmentCloud | principalType | scopesOrRoles |
+|---|---|---|---|---|---|
+| Cost query, budget, idle resource analysis | required | required | `AzureCloud`\* | `delegated-user` or `service-principal` | `CostManagement.Read`, `Consumption.Read`, Azure `Reader` |
+
+\* Use sovereign cloud values from the canonical contract when applicable.
+
+Fail fast before API calls when required context is missing or invalid. Redact tenant/subscription/object IDs in outputs.
+
 ## Base URLs
 
 ```

--- a/azure-policy-security/README.md
+++ b/azure-policy-security/README.md
@@ -8,6 +8,18 @@ Azure policy and security posture review workflows.
 - Prioritize remediation actions by risk and blast radius
 - Track compliance posture over time
 
+## Integration Context Contract
+- Canonical contract: [`docs/integration-context.md`](../docs/integration-context.md)
+
+| Command family | tenantId | subscriptionId | environmentCloud | principalType | scopesOrRoles |
+|---|---|---|---|---|---|
+| Policy coverage, drift, remediation | required | required | `AzureCloud`\* | `delegated-user` or `service-principal` | `PolicyInsights.Read`, `Policy.Read.All`, Azure `Reader` |
+
+\* Use sovereign cloud values from the contract when applicable.
+
+All commands must fail fast with `MissingIntegrationContext`, `InvalidIntegrationContext`, `ContextCloudMismatch`, or `InsufficientScopesOrRoles` before API calls.
+Outputs and reviewer notes must redact sensitive IDs using the contract rules.
+
 ## Included commands
 - `commands/setup.md`
 - `commands/policy-coverage.md`

--- a/azure-policy-security/commands/setup.md
+++ b/azure-policy-security/commands/setup.md
@@ -16,6 +16,18 @@ allowed-tools:
 
 Prepare posture analysis before running policy and security assessments.
 
+## Integration Context Fail-Fast Check
+
+Before any external API call, validate integration context from [`docs/integration-context.md`](../../docs/integration-context.md):
+- `tenantId` (always required)
+- `subscriptionId` (required for Azure-scope workflows)
+- `environmentCloud`
+- `principalType`
+- `scopesOrRoles`
+
+If validation fails, stop immediately and return a structured error using contract codes (`MissingIntegrationContext`, `InvalidIntegrationContext`, `ContextCloudMismatch`, `InsufficientScopesOrRoles`).
+Redact tenant/subscription/object identifiers in setup output using contract redaction rules.
+
 ## Step 1: Confirm Scope
 
 Confirm the governance scope: tenant, management group, or specific subscriptions. Provide explicit scope paths (e.g., `/providers/Microsoft.Management/managementGroups/<name>` or `/subscriptions/<id>`).

--- a/azure-policy-security/skills/azure-policy-security/SKILL.md
+++ b/azure-policy-security/skills/azure-policy-security/SKILL.md
@@ -35,6 +35,17 @@ triggers:
 
 This skill provides comprehensive knowledge for assessing Azure governance posture via the Azure Policy REST API — policy assignments, compliance state queries, initiatives, exemptions, and drift analysis with actionable remediation plans.
 
+## Integration Context Contract
+- Canonical contract: [`docs/integration-context.md`](../../../docs/integration-context.md)
+
+| Workflow | tenantId | subscriptionId | environmentCloud | principalType | scopesOrRoles |
+|---|---|---|---|---|---|
+| Policy coverage, drift, remediation | required | required | `AzureCloud`\* | `delegated-user` or `service-principal` | `PolicyInsights.Read`, `Policy.Read.All`, Azure `Reader` |
+
+\* Use sovereign cloud values from the canonical contract when applicable.
+
+Fail fast before API calls when required context is missing or invalid. Redact tenant/subscription/object IDs in outputs.
+
 ## Base URL
 
 ```

--- a/docs/integration-context.md
+++ b/docs/integration-context.md
@@ -1,0 +1,122 @@
+# Integration Context Contract
+
+Use this contract for cross-plugin Microsoft workflows so Azure and M365 commands run with consistent identity context.
+
+## Purpose
+- Standardize auth/runtime context across plugins.
+- Prevent tenant or subscription drift in multi-plugin chains.
+- Make command failures deterministic when required context is missing.
+
+## Standard Context Fields
+
+| Field | Type | Required | Description | Example |
+|---|---|---|---|---|
+| `tenantId` | string (GUID) | Yes | Microsoft Entra tenant GUID for all Graph/Azure calls. | `72f988bf-86f1-41af-91ab-2d7cd011db47` |
+| `subscriptionId` | string (GUID) | Azure commands only | Azure subscription GUID used for ARM scope resolution. | `11111111-2222-3333-4444-555555555555` |
+| `environmentCloud` | enum | Yes | Cloud boundary for endpoints and tokens. Allowed: `AzureCloud`, `AzureUSGovernment`, `AzureChinaCloud`. | `AzureCloud` |
+| `principalType` | enum | Yes | Identity type used to execute calls. Allowed: `delegated-user`, `service-principal`, `managed-identity`. | `delegated-user` |
+| `scopesOrRoles` | list[string] | Yes | Delegated Graph scopes and/or Azure RBAC roles required by the command. | `['Policy.Read.All','Reader']` |
+
+### Field Rules
+- Treat `tenantId` as mandatory for every plugin in this repository.
+- Treat `subscriptionId` as mandatory for Azure Resource Manager and Policy operations.
+- Use a single `environmentCloud` value across the full chain; do not mix public and sovereign clouds.
+- Declare `scopesOrRoles` at command granularity, not only plugin level.
+
+## Required Documentation Pattern
+
+Each plugin must document required context in **both** `README.md` and `skills/*/SKILL.md` using a section named `Integration Context Contract`.
+
+### Required section content
+1. Link to this contract: `docs/integration-context.md`.
+2. A plugin-specific table that maps command families to required values for:
+   - `tenantId`
+   - `subscriptionId` (if applicable)
+   - `environmentCloud`
+   - `principalType`
+   - `scopesOrRoles`
+3. A short fail-fast statement that points to the command behavior below.
+4. A short redaction statement that points to the redaction rules below.
+
+### Example snippet
+```md
+## Integration Context Contract
+- Canonical contract: `docs/integration-context.md`
+
+| Command family | tenantId | subscriptionId | environmentCloud | principalType | scopesOrRoles |
+|---|---|---|---|---|---|
+| Policy scan | required | required | AzureCloud | delegated-user or service-principal | PolicyInsights.Read, Reader |
+```
+
+## Command Fail-Fast Contract
+
+Commands must validate required context **before** making network/API calls.
+
+### Validation order
+1. Validate schema (required fields exist and type is correct).
+2. Validate cloud compatibility (endpoint set matches `environmentCloud`).
+3. Validate identity compatibility (`principalType` allowed for the command).
+4. Validate auth grants (`scopesOrRoles` satisfy minimum set).
+5. Validate resource scope (`subscriptionId` exists for Azure-scoped commands).
+
+### Standard fail-fast error format
+
+```json
+{
+  "error": {
+    "code": "MissingIntegrationContext",
+    "message": "Missing required context: subscriptionId",
+    "missingFields": ["subscriptionId"],
+    "requiredFor": "azure-policy-security/policy-coverage",
+    "nextAction": "Run /setup and provide tenantId + subscriptionId in integration context."
+  }
+}
+```
+
+### Error codes
+- `MissingIntegrationContext` - required field absent.
+- `InvalidIntegrationContext` - malformed GUID/enum/value.
+- `ContextCloudMismatch` - context cloud does not match endpoint family.
+- `InsufficientScopesOrRoles` - principal lacks required grants.
+
+## Redaction Rules
+
+Apply redaction in command output, logs, and reviewer reports.
+
+### Sensitive identifiers
+- Tenant IDs
+- Subscription IDs
+- Object IDs / principal IDs
+- Access token fragments, secrets, client secrets, certificates
+
+### Output redaction policy
+- Show only the first 6 and last 4 characters for GUID-like IDs.
+  - Example: `72f988...db47`
+- Never print bearer tokens or secrets, even partially.
+- For role/scope lists, keep values unredacted unless they include embedded secrets.
+- If a full identifier is required for replay, store it in secure state and display a handle/reference.
+
+### Reviewer and command docs
+- Reviewer agents must flag unredacted IDs/secrets as blocking findings.
+- Command docs must include at least one redacted example output.
+
+## Multi-Plugin Chain Handoff
+
+When handing off between plugins, pass a shared `integrationContext` object unchanged unless a command explicitly updates it.
+
+```json
+{
+  "integrationContext": {
+    "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+    "subscriptionId": "11111111-2222-3333-4444-555555555555",
+    "environmentCloud": "AzureCloud",
+    "principalType": "delegated-user",
+    "scopesOrRoles": [
+      "Policy.Read.All",
+      "PolicyInsights.Read",
+      "AuditLog.Read.All",
+      "Reader"
+    ]
+  }
+}
+```

--- a/entra-id-security/README.md
+++ b/entra-id-security/README.md
@@ -15,6 +15,18 @@ Run `/setup` to configure authentication and verify Entra ID access:
 /setup --minimal    # Node.js dependencies only
 ```
 
+## Integration Context Contract
+- Canonical contract: [`docs/integration-context.md`](../docs/integration-context.md)
+
+| Command family | tenantId | subscriptionId | environmentCloud | principalType | scopesOrRoles |
+|---|---|---|---|---|---|
+| App/SP/CA/sign-in/risk operations | required | optional (required only when chaining to Azure scope) | `AzureCloud`\* | `delegated-user` or `service-principal` | `Application.ReadWrite.All`, `Policy.Read.All`, `AuditLog.Read.All`, `Directory.Read.All` |
+
+\* Use sovereign cloud values from the contract when applicable.
+
+Commands must fail fast on missing context before issuing Graph calls and use standardized context error codes.
+All outputs/reviews must redact tenant/object identifiers using the contract redaction policy.
+
 ## Capabilities
 
 | Area | What Claude Can Do |

--- a/entra-id-security/commands/setup.md
+++ b/entra-id-security/commands/setup.md
@@ -16,6 +16,18 @@ allowed-tools:
 
 Guide the user through setting up Microsoft Entra ID security and identity management access.
 
+## Integration Context Fail-Fast Check
+
+Before any external API call, validate integration context from [`docs/integration-context.md`](../../docs/integration-context.md):
+- `tenantId` (always required)
+- `subscriptionId` (required for Azure-scope workflows)
+- `environmentCloud`
+- `principalType`
+- `scopesOrRoles`
+
+If validation fails, stop immediately and return a structured error using contract codes (`MissingIntegrationContext`, `InvalidIntegrationContext`, `ContextCloudMismatch`, `InsufficientScopesOrRoles`).
+Redact tenant/subscription/object identifiers in setup output using contract redaction rules.
+
 ## Step 1: Check Prerequisites
 
 Verify Node.js 18+ is installed.

--- a/entra-id-security/skills/entra-security/SKILL.md
+++ b/entra-id-security/skills/entra-security/SKILL.md
@@ -34,6 +34,18 @@ triggers:
 
 # Entra ID Security & Identity
 
+## Integration Context Contract
+- Canonical contract: [`docs/integration-context.md`](../../../docs/integration-context.md)
+
+| Workflow | tenantId | subscriptionId | environmentCloud | principalType | scopesOrRoles |
+|---|---|---|---|---|---|
+| App registration, CA policy, sign-in, risky user, permission audit | required | optional (for Azure chain handoff) | `AzureCloud`\* | `delegated-user` or `service-principal` | `Application.ReadWrite.All`, `Policy.Read.All`, `AuditLog.Read.All`, `Directory.Read.All` |
+
+\* Use sovereign cloud values from the canonical contract when applicable.
+
+Fail fast before Graph calls when required context is missing or invalid. Redact tenant/object identifiers in all outputs.
+
+
 ## Shared Workflow Routing
 - Use the shared workflow spec for deterministic multi-plugin routing: [`workflows/multi-plugin-workflows.md`](../../../workflows/multi-plugin-workflows.md#identitydata-risk-review-entra-id-security--purview-compliance--sharing-auditor).
 - Apply the trigger phrases, handoff contracts, auth prerequisites, validation checkpoints, and stop conditions before escalating to the next plugin.

--- a/license-optimizer/README.md
+++ b/license-optimizer/README.md
@@ -9,6 +9,18 @@ License optimization for MSPs/CSPs — find waste, recommend downgrades/upgrades
 - Multi-tenant Lighthouse reports for customer review meetings
 - CSP/Partner Center billing context
 
+## Integration Context Contract
+- Canonical contract: [`docs/integration-context.md`](../docs/integration-context.md)
+
+| Command family | tenantId | subscriptionId | environmentCloud | principalType | scopesOrRoles |
+|---|---|---|---|---|---|
+| License scan and reporting | required | optional | `AzureCloud`\* | `delegated-user` | `Directory.Read.All`, `User.Read.All`, `Reports.Read.All` |
+
+\* Use sovereign cloud values from the contract when applicable.
+
+Commands must fail fast when integration context is missing and return standard context error codes.
+Reports must redact sensitive tenant/user identifiers per the shared contract.
+
 ## Included commands
 - `/license-setup` — Configure Graph access for license reporting
 - `/license-scan` — Scan for inactive/underused licenses and savings opportunities

--- a/license-optimizer/commands/setup.md
+++ b/license-optimizer/commands/setup.md
@@ -16,6 +16,18 @@ allowed-tools:
 
 Guided setup for M365 license scanning and optimization.
 
+## Integration Context Fail-Fast Check
+
+Before any external API call, validate integration context from [`docs/integration-context.md`](../../docs/integration-context.md):
+- `tenantId` (always required)
+- `subscriptionId` (required for Azure-scope workflows)
+- `environmentCloud`
+- `principalType`
+- `scopesOrRoles`
+
+If validation fails, stop immediately and return a structured error using contract codes (`MissingIntegrationContext`, `InvalidIntegrationContext`, `ContextCloudMismatch`, `InsufficientScopesOrRoles`).
+Redact tenant/subscription/object identifiers in setup output using contract redaction rules.
+
 ## Step 1: Check Prerequisites
 
 - Graph API access with `User.Read.All`, `Directory.Read.All`, `Reports.Read.All`

--- a/license-optimizer/skills/license-optimizer/SKILL.md
+++ b/license-optimizer/skills/license-optimizer/SKILL.md
@@ -28,6 +28,17 @@ triggers:
 
 This skill provides comprehensive knowledge for identifying license waste, recommending right-sizing, managing group-based licensing, and generating savings reports for MSP/CSP customer review meetings via Graph API.
 
+## Integration Context Contract
+- Canonical contract: [`docs/integration-context.md`](../../../docs/integration-context.md)
+
+| Workflow | tenantId | subscriptionId | environmentCloud | principalType | scopesOrRoles |
+|---|---|---|---|---|---|
+| License scan, right-sizing, reporting | required | optional | `AzureCloud`\* | `delegated-user` | `Directory.Read.All`, `User.Read.All`, `Reports.Read.All` |
+
+\* Use sovereign cloud values from the canonical contract when applicable.
+
+Fail fast before Graph calls when required context is missing or invalid. Redact tenant/user identifiers in outputs.
+
 ## Base URL
 
 ```

--- a/lighthouse-health/README.md
+++ b/lighthouse-health/README.md
@@ -8,6 +8,18 @@ Multi-tenant health dashboard for MSPs/CSPs using Microsoft 365 Lighthouse. Prov
 - One-click remediation plan generation from scorecard findings
 - GDAP-aware multi-tenant operations
 
+## Integration Context Contract
+- Canonical contract: [`docs/integration-context.md`](../docs/integration-context.md)
+
+| Command family | tenantId | subscriptionId | environmentCloud | principalType | scopesOrRoles |
+|---|---|---|---|---|---|
+| Lighthouse health and remediation | required (partner + customer context) | optional | `AzureCloud`\* | `delegated-user` | `DelegatedAdminRelationship.Read.All`, `Directory.Read.All`, `AuditLog.Read.All` |
+
+\* Use sovereign cloud values from the contract when applicable.
+
+Commands must fail fast if tenant chain context is incomplete, before scanning managed tenants.
+Outputs must redact partner/customer tenant and object identifiers per contract.
+
 ## Included commands
 - `/lighthouse-setup` — Configure Lighthouse access and GDAP relationships
 - `/lighthouse-health-scan` — Scan tenants and produce health scorecard

--- a/lighthouse-health/commands/setup.md
+++ b/lighthouse-health/commands/setup.md
@@ -16,6 +16,18 @@ allowed-tools:
 
 Guided setup for MSP/CSP Lighthouse health scanning.
 
+## Integration Context Fail-Fast Check
+
+Before any external API call, validate integration context from [`docs/integration-context.md`](../../docs/integration-context.md):
+- `tenantId` (always required)
+- `subscriptionId` (required for Azure-scope workflows)
+- `environmentCloud`
+- `principalType`
+- `scopesOrRoles`
+
+If validation fails, stop immediately and return a structured error using contract codes (`MissingIntegrationContext`, `InvalidIntegrationContext`, `ContextCloudMismatch`, `InsufficientScopesOrRoles`).
+Redact tenant/subscription/object identifiers in setup output using contract redaction rules.
+
 ## Step 1: Verify Partner Tenant
 
 - Confirm the user has a Microsoft Partner Center account

--- a/lighthouse-health/skills/lighthouse-health/SKILL.md
+++ b/lighthouse-health/skills/lighthouse-health/SKILL.md
@@ -28,6 +28,17 @@ triggers:
 
 This skill provides comprehensive knowledge for managing multiple Microsoft 365 customer tenants via Lighthouse, with focus on health scoring, GDAP relationship management, and remediation planning for MSPs/CSPs.
 
+## Integration Context Contract
+- Canonical contract: [`docs/integration-context.md`](../../../docs/integration-context.md)
+
+| Workflow | tenantId | subscriptionId | environmentCloud | principalType | scopesOrRoles |
+|---|---|---|---|---|---|
+| Multi-tenant health scoring and remediation | required (partner + customer) | optional | `AzureCloud`\* | `delegated-user` | `DelegatedAdminRelationship.Read.All`, `Directory.Read.All`, `AuditLog.Read.All` |
+
+\* Use sovereign cloud values from the canonical contract when applicable.
+
+Fail fast before scanning tenants when required context is missing or invalid. Redact partner/customer IDs in outputs.
+
 ## Base URL
 
 ```

--- a/m365-admin/README.md
+++ b/m365-admin/README.md
@@ -27,6 +27,19 @@ Run `/setup` to configure authentication and install dependencies:
 /setup --with-sharepoint-pnp    # Include PnP PowerShell module
 ```
 
+## Integration Context Contract
+- Canonical contract: [`docs/integration-context.md`](../docs/integration-context.md)
+
+| Command family | tenantId | subscriptionId | environmentCloud | principalType | scopesOrRoles |
+|---|---|---|---|---|---|
+| User/group/license/admin workflows | required | optional (only when chaining with Azure plugins) | `AzureCloud`\* | `delegated-user` | `User.ReadWrite.All`, `Group.ReadWrite.All`, `Directory.ReadWrite.All`, `AuditLog.Read.All` |
+| Exchange/SharePoint admin workflows | required | optional | `AzureCloud`\* | `delegated-user` | `MailboxSettings.ReadWrite`, `Mail.ReadWrite`, `Sites.FullControl.All` |
+
+\* Use sovereign cloud values from the contract when applicable.
+
+Every command must validate required context up front and fail fast with contract error codes before Graph/PowerShell execution.
+Examples and reports must redact sensitive identifiers per the shared contract.
+
 ## Authentication
 
 All operations use delegated authentication with interactive browser login (MSAL). Scopes are requested dynamically based on the operation following the principle of least privilege.

--- a/m365-admin/commands/setup.md
+++ b/m365-admin/commands/setup.md
@@ -24,6 +24,18 @@ Interactive guided setup for the M365 Admin plugin. Checks prerequisites, instal
 
 Default (no flags): Full guided setup including Node.js dependencies, Azure app registration, and connectivity verification. Exchange and PnP modules are offered as optional steps.
 
+## Integration Context Fail-Fast Check
+
+Before any external API call, validate integration context from [`docs/integration-context.md`](../../docs/integration-context.md):
+- `tenantId` (always required)
+- `subscriptionId` (required for Azure-scope workflows)
+- `environmentCloud`
+- `principalType`
+- `scopesOrRoles`
+
+If validation fails, stop immediately and return a structured error using contract codes (`MissingIntegrationContext`, `InvalidIntegrationContext`, `ContextCloudMismatch`, `InsufficientScopesOrRoles`).
+Redact tenant/subscription/object identifiers in setup output using contract redaction rules.
+
 ## Step 1: Check Prerequisites
 
 Verify the following tools are available on the system. Report version and status for each.

--- a/m365-admin/skills/m365-admin/SKILL.md
+++ b/m365-admin/skills/m365-admin/SKILL.md
@@ -34,6 +34,19 @@ triggers:
 
 This skill provides comprehensive knowledge for administering a Microsoft 365 tenant through the Microsoft Graph API. It covers user lifecycle management, license assignment, group administration, Exchange Online mailbox operations, SharePoint site management, and bulk processing patterns. All operations use delegated authentication with least-privilege scopes and produce structured reports.
 
+## Integration Context Contract
+- Canonical contract: [`docs/integration-context.md`](../../../docs/integration-context.md)
+
+| Workflow | tenantId | subscriptionId | environmentCloud | principalType | scopesOrRoles |
+|---|---|---|---|---|---|
+| User, group, license, audit workflows | required | optional (for Azure chain handoff) | `AzureCloud`\* | `delegated-user` | `User.ReadWrite.All`, `Group.ReadWrite.All`, `Directory.ReadWrite.All`, `AuditLog.Read.All` |
+| Exchange and SharePoint admin workflows | required | optional | `AzureCloud`\* | `delegated-user` | `MailboxSettings.ReadWrite`, `Mail.ReadWrite`, `Sites.FullControl.All` |
+
+\* Use sovereign cloud values from the canonical contract when applicable.
+
+Fail fast before Graph/PowerShell execution when required context is missing or invalid. Redact tenant and object identifiers in outputs.
+
+
 ## Microsoft Graph Admin API Overview
 
 The Microsoft Graph API is the unified gateway to data and intelligence in Microsoft 365. All admin operations target the base URL:

--- a/purview-compliance/README.md
+++ b/purview-compliance/README.md
@@ -9,6 +9,18 @@ Compliance workflow guidance for Microsoft Purview — DLP, retention, sensitivi
 - eDiscovery case workflow preparation
 - **Guided compliance playbooks** with audit-ready change logs and owner sign-off
 
+## Integration Context Contract
+- Canonical contract: [`docs/integration-context.md`](../docs/integration-context.md)
+
+| Command family | tenantId | subscriptionId | environmentCloud | principalType | scopesOrRoles |
+|---|---|---|---|---|---|
+| DLP/retention/ediscovery/playbooks | required | optional (required only for Azure-linked evidence sources) | `AzureCloud`\* | `delegated-user` | `Compliance.Read.All`, `SecurityEvents.Read.All`, `AuditLog.Read.All` |
+
+\* Use sovereign cloud values from the contract when applicable.
+
+Commands must validate context first and fail fast with shared error codes when prerequisites are missing.
+Sample outputs must redact tenant and principal identifiers per contract.
+
 ## Included commands
 - `/purview-setup` — Configure regulatory context, tenant scope, and PowerShell connectivity
 - `/dlp-review` — Review DLP policy coverage and false-positive hotspots

--- a/purview-compliance/commands/setup.md
+++ b/purview-compliance/commands/setup.md
@@ -16,6 +16,18 @@ allowed-tools:
 
 Interactive guided setup for the Purview Compliance plugin. Establishes regulatory context, confirms tenant scope, and verifies connectivity.
 
+## Integration Context Fail-Fast Check
+
+Before any external API call, validate integration context from [`docs/integration-context.md`](../../docs/integration-context.md):
+- `tenantId` (always required)
+- `subscriptionId` (required for Azure-scope workflows)
+- `environmentCloud`
+- `principalType`
+- `scopesOrRoles`
+
+If validation fails, stop immediately and return a structured error using contract codes (`MissingIntegrationContext`, `InvalidIntegrationContext`, `ContextCloudMismatch`, `InsufficientScopesOrRoles`).
+Redact tenant/subscription/object identifiers in setup output using contract redaction rules.
+
 ## Step 1: Confirm Regulatory Context
 
 Ask the user:

--- a/purview-compliance/skills/purview-compliance/SKILL.md
+++ b/purview-compliance/skills/purview-compliance/SKILL.md
@@ -45,6 +45,17 @@ This skill provides comprehensive knowledge for managing Microsoft Purview compl
 3. **Legally aware** — Flag when legal counsel should be involved
 4. **Non-destructive** — Prefer test mode, dry runs, and gradual rollouts
 
+## Integration Context Contract
+- Canonical contract: [`docs/integration-context.md`](../../../docs/integration-context.md)
+
+| Workflow | tenantId | subscriptionId | environmentCloud | principalType | scopesOrRoles |
+|---|---|---|---|---|---|
+| DLP, retention, eDiscovery, compliance playbooks | required | optional (Azure-linked evidence only) | `AzureCloud`\* | `delegated-user` | `Compliance.Read.All`, `SecurityEvents.Read.All`, `AuditLog.Read.All` |
+
+\* Use sovereign cloud values from the canonical contract when applicable.
+
+Fail fast before compliance queries when required context is missing or invalid. Redact tenant/object identifiers in outputs.
+
 ## Base URLs
 
 ```

--- a/sharing-auditor/README.md
+++ b/sharing-auditor/README.md
@@ -8,6 +8,18 @@ Find overshared links, anonymous access, and stale guest users across SharePoint
 - Audit external sharing policies across site collections
 - Generate approval-based revocation tasks (no accidental hard deletes)
 
+## Integration Context Contract
+- Canonical contract: [`docs/integration-context.md`](../docs/integration-context.md)
+
+| Command family | tenantId | subscriptionId | environmentCloud | principalType | scopesOrRoles |
+|---|---|---|---|---|---|
+| Sharing scans and remediation plans | required | optional | `AzureCloud`\* | `delegated-user` | `Sites.Read.All`, `Sites.FullControl.All`, `User.Read.All`, `AuditLog.Read.All` |
+
+\* Use sovereign cloud values from the contract when applicable.
+
+Commands must fail fast before Graph/SharePoint calls when required context fields are missing.
+Results must redact sensitive IDs according to the shared redaction rules.
+
 ## Included commands
 - `/sharing-setup` — Configure SharePoint admin and Graph access
 - `/sharing-scan` — Scan for overshared links, anonymous access, and stale guests

--- a/sharing-auditor/commands/setup.md
+++ b/sharing-auditor/commands/setup.md
@@ -16,6 +16,18 @@ allowed-tools:
 
 Guided setup for SharePoint/OneDrive external sharing auditing.
 
+## Integration Context Fail-Fast Check
+
+Before any external API call, validate integration context from [`docs/integration-context.md`](../../docs/integration-context.md):
+- `tenantId` (always required)
+- `subscriptionId` (required for Azure-scope workflows)
+- `environmentCloud`
+- `principalType`
+- `scopesOrRoles`
+
+If validation fails, stop immediately and return a structured error using contract codes (`MissingIntegrationContext`, `InvalidIntegrationContext`, `ContextCloudMismatch`, `InsufficientScopesOrRoles`).
+Redact tenant/subscription/object identifiers in setup output using contract redaction rules.
+
 ## Step 1: Check Prerequisites
 
 - Graph API access with `Sites.Read.All`, `User.Read.All`

--- a/sharing-auditor/skills/sharing-auditor/SKILL.md
+++ b/sharing-auditor/skills/sharing-auditor/SKILL.md
@@ -33,6 +33,17 @@ triggers:
 
 This skill provides comprehensive knowledge for auditing and managing external sharing across SharePoint and OneDrive via Graph API and SharePoint PowerShell, with a focus on safe remediation that avoids accidental data loss.
 
+## Integration Context Contract
+- Canonical contract: [`docs/integration-context.md`](../../../docs/integration-context.md)
+
+| Workflow | tenantId | subscriptionId | environmentCloud | principalType | scopesOrRoles |
+|---|---|---|---|---|---|
+| Sharing scan and remediation | required | optional | `AzureCloud`\* | `delegated-user` | `Sites.Read.All`, `Sites.FullControl.All`, `User.Read.All`, `AuditLog.Read.All` |
+
+\* Use sovereign cloud values from the canonical contract when applicable.
+
+Fail fast before Graph/SharePoint calls when required context is missing or invalid. Redact tenant/object identifiers in outputs.
+
 ## Base URL
 
 ```


### PR DESCRIPTION
### Motivation
- Reduce cross-plugin authentication/context drift by defining a single integration contract for Azure and M365 workflows so multi-plugin chains share a deterministic identity context.
- Ensure commands fail fast and deterministically when required context is missing or invalid to avoid partial or inconsistent API calls across plugins.
- Protect sensitive identifiers in outputs by prescribing a standard redaction policy for commands and reviewer reports.

### Description
- Add `docs/integration-context.md` with canonical context fields (`tenantId`, `subscriptionId`, `environmentCloud`, `principalType`, `scopesOrRoles`), validation order, standard fail-fast error format, error codes, redaction rules, and a multi-plugin `integrationContext` handoff example.
- Retrofit Azure and M365 plugin docs to reference the contract by adding an `Integration Context Contract` section to `README.md` and `skills/*/SKILL.md` for: `azure-policy-security`, `azure-cost-governance`, `m365-admin`, `entra-id-security`, `purview-compliance`, `sharing-auditor`, `lighthouse-health`, and `license-optimizer`.
- Add an `Integration Context Fail-Fast Check` subsection into each plugin's `commands/setup.md` to require up-front validation (schema, cloud, principal type, scopes/roles, subscriptionId where applicable) and to instruct standardized error responses and redaction of identifiers.
- Include guidance in docs for command-level `scopesOrRoles`, cloud compatibility, and reviewer agents flagging unredacted identifiers as blocking findings.

### Testing
- Ran `npm run validate:all` and confirmed the marketplace schema validation step passed successfully.
- The full validation run surfaced pre-existing repository-wide description drift and deterministic-step warnings unrelated to the integration contract changes, and no new validation errors were introduced by the modified files.
- Basic file-level checks were performed to ensure each targeted `README.md`, `SKILL.md`, and `commands/setup.md` contains the added contract or fail-fast section.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a526449248832aac7c5023d1c042d4)