### PR TITLE
Add capability graph generation and strict metadata drift checks

### DIFF
--- a/artifacts/capability-graph.json
+++ b/artifacts/capability-graph.json
@@ -1,0 +1,4624 @@
+{
+  "strictPluginScope": [],
+  "sourceFiles": {
+    "claudeCatalog": "CLAUDE.md",
+    "marketplace": ".claude-plugin/marketplace.json"
+  },
+  "plugins": {
+    "excel-office-scripts": {
+      "category": "productivity",
+      "description": "Deep knowledge of Excel Office Scripts (TypeScript 4.0.3, ExcelScript API) and Power Automate cloud flow creation via Dataverse Web API.",
+      "files": {
+        "manifest": "excel-office-scripts/.claude-plugin/plugin.json",
+        "readme": "excel-office-scripts/README.md",
+        "skills": [
+          "excel-office-scripts/skills/office-scripts/SKILL.md",
+          "excel-office-scripts/skills/power-automate-flows/SKILL.md"
+        ],
+        "commands": [
+          "excel-office-scripts/commands/create-flow.md",
+          "excel-office-scripts/commands/create-script.md",
+          "excel-office-scripts/commands/validate-script.md"
+        ],
+        "agents": [
+          "excel-office-scripts/agents/flow-definition-reviewer.md",
+          "excel-office-scripts/agents/office-script-reviewer.md"
+        ]
+      },
+      "domains": {
+        "productivity": {
+          "actions": [
+            {
+              "name": "create-flow",
+              "description": "\"Generate a Power Automate flow definition JSON from a description\"",
+              "source": "excel-office-scripts/commands/create-flow.md"
+            },
+            {
+              "name": "create-script",
+              "description": "\"Create a new Excel Office Script from a description\"",
+              "source": "excel-office-scripts/commands/create-script.md"
+            },
+            {
+              "name": "validate-script",
+              "description": "\"Validate an Office Script for compliance and best practices\"",
+              "source": "excel-office-scripts/commands/validate-script.md"
+            }
+          ],
+          "prerequisites": []
+        }
+      }
+    },
+    "m365-platform-clients": {
+      "category": "cloud",
+      "description": "TypeScript patterns for Dataverse Web API and Microsoft Graph with shared Azure Identity auth, typed clients, and combined provisioning workflows.",
+      "files": {
+        "manifest": "m365-platform-clients/.claude-plugin/plugin.json",
+        "readme": "m365-platform-clients/README.md",
+        "skills": [
+          "m365-platform-clients/skills/m365-clients/SKILL.md"
+        ],
+        "commands": [
+          "m365-platform-clients/commands/create-m365-client.md"
+        ],
+        "agents": [
+          "m365-platform-clients/agents/m365-client-reviewer.md"
+        ]
+      },
+      "domains": {
+        "cloud": {
+          "actions": [
+            {
+              "name": "create-m365-client",
+              "description": "Generate TypeScript client code for Dataverse Web API and/or Microsoft Graph with shared Azure Identity auth",
+              "source": "m365-platform-clients/commands/create-m365-client.md"
+            }
+          ],
+          "prerequisites": []
+        }
+      }
+    },
+    "excel-automation": {
+      "category": "productivity",
+      "description": "Clean messy data with pandas, generate Office Scripts and Power Automate flows, and create Excel templates — with Dataverse-aware mode and VBA fallback.",
+      "files": {
+        "manifest": "excel-automation/.claude-plugin/plugin.json",
+        "readme": "excel-automation/README.md",
+        "skills": [
+          "excel-automation/skills/office-scripts/SKILL.md",
+          "excel-automation/skills/pandas-cleaning/SKILL.md",
+          "excel-automation/skills/power-automate-flows/SKILL.md"
+        ],
+        "commands": [
+          "excel-automation/commands/create-flow.md",
+          "excel-automation/commands/create-script.md",
+          "excel-automation/commands/excel-clean.md",
+          "excel-automation/commands/excel-script.md",
+          "excel-automation/commands/excel-template.md",
+          "excel-automation/commands/excel-vba.md",
+          "excel-automation/commands/setup.md",
+          "excel-automation/commands/validate-script.md"
+        ],
+        "agents": [
+          "excel-automation/agents/excel-reviewer.md",
+          "excel-automation/agents/flow-definition-reviewer.md"
+        ]
+      },
+      "domains": {
+        "pandas-cleaning": {
+          "actions": [
+            {
+              "name": "create-flow",
+              "description": "\"Generate a Power Automate flow definition JSON from a description\"",
+              "source": "excel-automation/commands/create-flow.md"
+            },
+            {
+              "name": "create-script",
+              "description": "\"Create a new Excel Office Script from a description\"",
+              "source": "excel-automation/commands/create-script.md"
+            },
+            {
+              "name": "excel-clean",
+              "description": "\"Clean messy data with pandas and output a polished .xlsx file\"",
+              "source": "excel-automation/commands/excel-clean.md"
+            },
+            {
+              "name": "excel-script",
+              "description": "\"Generate an Office Script for Excel formatting and automation\"",
+              "source": "excel-automation/commands/excel-script.md"
+            },
+            {
+              "name": "excel-template",
+              "description": "\"Generate a reusable Excel template with headers, validation, and formatting\"",
+              "source": "excel-automation/commands/excel-template.md"
+            },
+            {
+              "name": "excel-vba",
+              "description": "\"Generate VBA macro code (deprecated — use /excel-script for Office Scripts instead)\"",
+              "source": "excel-automation/commands/excel-vba.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Excel Automation plugin — install Python dependencies, configure auth, and verify connectivity",
+              "source": "excel-automation/commands/setup.md"
+            },
+            {
+              "name": "validate-script",
+              "description": "\"Validate an Office Script for compliance and best practices\"",
+              "source": "excel-automation/commands/validate-script.md"
+            }
+          ],
+          "prerequisites": []
+        },
+        "office-scripts": {
+          "actions": [
+            {
+              "name": "create-flow",
+              "description": "\"Generate a Power Automate flow definition JSON from a description\"",
+              "source": "excel-automation/commands/create-flow.md"
+            },
+            {
+              "name": "create-script",
+              "description": "\"Create a new Excel Office Script from a description\"",
+              "source": "excel-automation/commands/create-script.md"
+            },
+            {
+              "name": "excel-clean",
+              "description": "\"Clean messy data with pandas and output a polished .xlsx file\"",
+              "source": "excel-automation/commands/excel-clean.md"
+            },
+            {
+              "name": "excel-script",
+              "description": "\"Generate an Office Script for Excel formatting and automation\"",
+              "source": "excel-automation/commands/excel-script.md"
+            },
+            {
+              "name": "excel-template",
+              "description": "\"Generate a reusable Excel template with headers, validation, and formatting\"",
+              "source": "excel-automation/commands/excel-template.md"
+            },
+            {
+              "name": "excel-vba",
+              "description": "\"Generate VBA macro code (deprecated — use /excel-script for Office Scripts instead)\"",
+              "source": "excel-automation/commands/excel-vba.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Excel Automation plugin — install Python dependencies, configure auth, and verify connectivity",
+              "source": "excel-automation/commands/setup.md"
+            },
+            {
+              "name": "validate-script",
+              "description": "\"Validate an Office Script for compliance and best practices\"",
+              "source": "excel-automation/commands/validate-script.md"
+            }
+          ],
+          "prerequisites": []
+        },
+        "power-automate-flows": {
+          "actions": [
+            {
+              "name": "create-flow",
+              "description": "\"Generate a Power Automate flow definition JSON from a description\"",
+              "source": "excel-automation/commands/create-flow.md"
+            },
+            {
+              "name": "create-script",
+              "description": "\"Create a new Excel Office Script from a description\"",
+              "source": "excel-automation/commands/create-script.md"
+            },
+            {
+              "name": "excel-clean",
+              "description": "\"Clean messy data with pandas and output a polished .xlsx file\"",
+              "source": "excel-automation/commands/excel-clean.md"
+            },
+            {
+              "name": "excel-script",
+              "description": "\"Generate an Office Script for Excel formatting and automation\"",
+              "source": "excel-automation/commands/excel-script.md"
+            },
+            {
+              "name": "excel-template",
+              "description": "\"Generate a reusable Excel template with headers, validation, and formatting\"",
+              "source": "excel-automation/commands/excel-template.md"
+            },
+            {
+              "name": "excel-vba",
+              "description": "\"Generate VBA macro code (deprecated — use /excel-script for Office Scripts instead)\"",
+              "source": "excel-automation/commands/excel-vba.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Excel Automation plugin — install Python dependencies, configure auth, and verify connectivity",
+              "source": "excel-automation/commands/setup.md"
+            },
+            {
+              "name": "validate-script",
+              "description": "\"Validate an Office Script for compliance and best practices\"",
+              "source": "excel-automation/commands/validate-script.md"
+            }
+          ],
+          "prerequisites": []
+        },
+        "excel-reviewer": {
+          "actions": [
+            {
+              "name": "create-flow",
+              "description": "\"Generate a Power Automate flow definition JSON from a description\"",
+              "source": "excel-automation/commands/create-flow.md"
+            },
+            {
+              "name": "create-script",
+              "description": "\"Create a new Excel Office Script from a description\"",
+              "source": "excel-automation/commands/create-script.md"
+            },
+            {
+              "name": "excel-clean",
+              "description": "\"Clean messy data with pandas and output a polished .xlsx file\"",
+              "source": "excel-automation/commands/excel-clean.md"
+            },
+            {
+              "name": "excel-script",
+              "description": "\"Generate an Office Script for Excel formatting and automation\"",
+              "source": "excel-automation/commands/excel-script.md"
+            },
+            {
+              "name": "excel-template",
+              "description": "\"Generate a reusable Excel template with headers, validation, and formatting\"",
+              "source": "excel-automation/commands/excel-template.md"
+            },
+            {
+              "name": "excel-vba",
+              "description": "\"Generate VBA macro code (deprecated — use /excel-script for Office Scripts instead)\"",
+              "source": "excel-automation/commands/excel-vba.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Excel Automation plugin — install Python dependencies, configure auth, and verify connectivity",
+              "source": "excel-automation/commands/setup.md"
+            },
+            {
+              "name": "validate-script",
+              "description": "\"Validate an Office Script for compliance and best practices\"",
+              "source": "excel-automation/commands/validate-script.md"
+            }
+          ],
+          "prerequisites": []
+        },
+        "flow-definition-reviewer": {
+          "actions": [
+            {
+              "name": "create-flow",
+              "description": "\"Generate a Power Automate flow definition JSON from a description\"",
+              "source": "excel-automation/commands/create-flow.md"
+            },
+            {
+              "name": "create-script",
+              "description": "\"Create a new Excel Office Script from a description\"",
+              "source": "excel-automation/commands/create-script.md"
+            },
+            {
+              "name": "excel-clean",
+              "description": "\"Clean messy data with pandas and output a polished .xlsx file\"",
+              "source": "excel-automation/commands/excel-clean.md"
+            },
+            {
+              "name": "excel-script",
+              "description": "\"Generate an Office Script for Excel formatting and automation\"",
+              "source": "excel-automation/commands/excel-script.md"
+            },
+            {
+              "name": "excel-template",
+              "description": "\"Generate a reusable Excel template with headers, validation, and formatting\"",
+              "source": "excel-automation/commands/excel-template.md"
+            },
+            {
+              "name": "excel-vba",
+              "description": "\"Generate VBA macro code (deprecated — use /excel-script for Office Scripts instead)\"",
+              "source": "excel-automation/commands/excel-vba.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Excel Automation plugin — install Python dependencies, configure auth, and verify connectivity",
+              "source": "excel-automation/commands/setup.md"
+            },
+            {
+              "name": "validate-script",
+              "description": "\"Validate an Office Script for compliance and best practices\"",
+              "source": "excel-automation/commands/validate-script.md"
+            }
+          ],
+          "prerequisites": []
+        }
+      }
+    },
+    "m365-admin": {
+      "category": "cloud",
+      "description": "M365 tenant admin via Microsoft Graph — users, groups, licenses, Exchange Online, SharePoint, and CSV-driven bulk operations.",
+      "files": {
+        "manifest": "m365-admin/.claude-plugin/plugin.json",
+        "readme": "m365-admin/README.md",
+        "skills": [
+          "m365-admin/skills/m365-admin/SKILL.md"
+        ],
+        "commands": [
+          "m365-admin/commands/m365-audit.md",
+          "m365-admin/commands/m365-exchange-mailbox.md",
+          "m365-admin/commands/m365-group-create.md",
+          "m365-admin/commands/m365-license-assign.md",
+          "m365-admin/commands/m365-offboard-wizard.md",
+          "m365-admin/commands/m365-onboard-wizard.md",
+          "m365-admin/commands/m365-sharepoint-site.md",
+          "m365-admin/commands/m365-user-create.md",
+          "m365-admin/commands/m365-user-offboard.md",
+          "m365-admin/commands/setup.md"
+        ],
+        "agents": [
+          "m365-admin/agents/m365-admin-reviewer.md"
+        ]
+      },
+      "domains": {
+        "cloud": {
+          "actions": [
+            {
+              "name": "m365-audit",
+              "description": "Generate M365 audit reports — sign-in logs, directory changes, license usage, permission audits. Export as markdown tables or CSV.",
+              "source": "m365-admin/commands/m365-audit.md"
+            },
+            {
+              "name": "m365-exchange-mailbox",
+              "description": "Exchange Online mailbox operations — create shared mailbox, set auto-reply, manage delegates, convert user mailbox to shared.",
+              "source": "m365-admin/commands/m365-exchange-mailbox.md"
+            },
+            {
+              "name": "m365-group-create",
+              "description": "Create an M365 group — security group, M365 (Unified) group, or distribution list. Optionally add initial members from CSV.",
+              "source": "m365-admin/commands/m365-group-create.md"
+            },
+            {
+              "name": "m365-license-assign",
+              "description": "Assign, change, or revoke M365 licenses. Lists available SKUs, validates availability, and supports bulk operations from CSV.",
+              "source": "m365-admin/commands/m365-license-assign.md"
+            },
+            {
+              "name": "m365-offboard-wizard",
+              "description": "Guided employee offboarding checklist — mailbox forwarding, OneDrive transfer, license removal, session revocation, risky app cleanup, and access review. Supports Lighthouse multi-tenant batch mode.",
+              "source": "m365-admin/commands/m365-offboard-wizard.md"
+            },
+            {
+              "name": "m365-onboard-wizard",
+              "description": "Guided \"Set up new employee\" wizard — create account, assign license, add to groups, provision Teams, set up OneDrive folder template, and send welcome email. Supports Lighthouse multi-tenant mode.",
+              "source": "m365-admin/commands/m365-onboard-wizard.md"
+            },
+            {
+              "name": "m365-sharepoint-site",
+              "description": "SharePoint site operations — create site, manage permissions, set sharing policy, associate with hub site.",
+              "source": "m365-admin/commands/m365-sharepoint-site.md"
+            },
+            {
+              "name": "m365-user-create",
+              "description": "Create M365 user(s) with license and group assignment. Supports single user from params or bulk from CSV. Includes validation and dry-run.",
+              "source": "m365-admin/commands/m365-user-create.md"
+            },
+            {
+              "name": "m365-user-offboard",
+              "description": "Offboard M365 user(s) — disable account, revoke licenses, remove from groups, set auto-reply, convert mailbox to shared, transfer OneDrive. Supports bulk from CSV.",
+              "source": "m365-admin/commands/m365-user-offboard.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the M365 Admin plugin — configure Azure app registration, install dependencies, and verify Graph API connectivity",
+              "source": "m365-admin/commands/setup.md"
+            }
+          ],
+          "prerequisites": [
+            "Directory: Users with admin roles, role assignments",
+            "SharePoint: Site permissions, external sharing links, guest access",
+            "`--action <list|grant|revoke>`: Permission action",
+            "`--include-external`: Include external sharing details",
+            "`--role <read|write|owner>`: Permission level",
+            "`--scope <directory|sharepoint|all>`: What to audit",
+            "`--site <siteUrl>`: Specific SharePoint site to audit (for sharepoint scope)",
+            "`--url <siteUrl>`: Target site URL",
+            "`--user <upn>`: User to grant/revoke"
+          ]
+        }
+      }
+    },
+    "dataverse-schema": {
+      "category": "cloud",
+      "description": "Create and manage Dataverse tables, columns, relationships, and solutions via Web API — with FetchXML generation and data seeding.",
+      "files": {
+        "manifest": "dataverse-schema/.claude-plugin/plugin.json",
+        "readme": "dataverse-schema/README.md",
+        "skills": [
+          "dataverse-schema/skills/dataverse-schema/SKILL.md"
+        ],
+        "commands": [
+          "dataverse-schema/commands/dataverse-column-add.md",
+          "dataverse-schema/commands/dataverse-optionset-create.md",
+          "dataverse-schema/commands/dataverse-query.md",
+          "dataverse-schema/commands/dataverse-relationship-create.md",
+          "dataverse-schema/commands/dataverse-seed.md",
+          "dataverse-schema/commands/dataverse-solution-export.md",
+          "dataverse-schema/commands/dataverse-solution-import.md",
+          "dataverse-schema/commands/dataverse-table-create.md",
+          "dataverse-schema/commands/setup.md"
+        ],
+        "agents": [
+          "dataverse-schema/agents/schema-reviewer.md"
+        ]
+      },
+      "domains": {
+        "cloud": {
+          "actions": [
+            {
+              "name": "dataverse-column-add",
+              "description": "Add a column to an existing Dataverse table via the Web API",
+              "source": "dataverse-schema/commands/dataverse-column-add.md"
+            },
+            {
+              "name": "dataverse-optionset-create",
+              "description": "Create a global or local option set (choice column) in Dataverse",
+              "source": "dataverse-schema/commands/dataverse-optionset-create.md"
+            },
+            {
+              "name": "dataverse-query",
+              "description": "Generate a FetchXML or OData query for Dataverse data retrieval",
+              "source": "dataverse-schema/commands/dataverse-query.md"
+            },
+            {
+              "name": "dataverse-relationship-create",
+              "description": "Create a relationship (1:N or N:N) between Dataverse tables",
+              "source": "dataverse-schema/commands/dataverse-relationship-create.md"
+            },
+            {
+              "name": "dataverse-seed",
+              "description": "Seed data into a Dataverse table from CSV, JSON, or generated test data",
+              "source": "dataverse-schema/commands/dataverse-seed.md"
+            },
+            {
+              "name": "dataverse-solution-export",
+              "description": "Export a Dataverse solution as managed or unmanaged zip",
+              "source": "dataverse-schema/commands/dataverse-solution-export.md"
+            },
+            {
+              "name": "dataverse-solution-import",
+              "description": "Import a Dataverse solution zip into a target environment",
+              "source": "dataverse-schema/commands/dataverse-solution-import.md"
+            },
+            {
+              "name": "dataverse-table-create",
+              "description": "Create a new Dataverse custom table with columns via the Web API",
+              "source": "dataverse-schema/commands/dataverse-table-create.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Dataverse Schema plugin — configure environment URL, auth credentials, publisher prefix, and verify Web API connectivity",
+              "source": "dataverse-schema/commands/setup.md"
+            }
+          ],
+          "prerequisites": [
+            "**Aggregation** needs (count, sum, average, group by)",
+            "**Child/Referencing table** (the \"many\" side for 1:N, or Entity2 for N:N)",
+            "**Column display name** (e.g., \"Estimated Hours\")",
+            "**Column type** or a description of what the column stores (use the column type decision tree to determine the correct type)",
+            "**Data source**: One of:",
+            "**Description** of what the table stores",
+            "**Environment URL**",
+            "**Export type**: Managed or Unmanaged (default: both)",
+            "**Filter conditions** (status, date range, specific values, related record conditions)",
+            "**Global or Local**:",
+            "**Import options**:",
+            "**Initial columns** beyond the primary name column (optional, can be added later)",
+            "**Option set name** (display name, e.g., \"Task Priority\")",
+            "**Options**: List of choices with labels (values will be auto-assigned if not specified)",
+            "**Output directory** for the zip file",
+            "**Ownership type**: UserOwned (default) or OrganizationOwned",
+            "**Pagination** requirements (page size, specific page)",
+            "**Parent/Referenced table** (the \"one\" side for 1:N, or Entity1 for N:N)",
+            "**Preferred format**: FetchXML or OData (recommend FetchXML for complex queries, OData for simple ones)",
+            "**Publisher prefix** (e.g., `cr123`)",
+            "**Publisher prefix** (e.g., `cr123`) — ask if not obvious from context",
+            "**Related data** to include (join/expand other tables)",
+            "**Relationship type**: 1:N (One-to-Many) or N:N (Many-to-Many)",
+            "**Required level**: None, Recommended, or ApplicationRequired",
+            "**Script language**: TypeScript (default) or Bash/curl",
+            "**Solution unique name**",
+            "**Solution unique name** (e.g., `ContosoProjectManagement`)",
+            "**Solution unique name** — ask if not obvious from context",
+            "**Solution zip file path** (local path to the .zip file)",
+            "**Sorting** requirements",
+            "**Synchronous or Asynchronous**: Async recommended for production",
+            "**Table logical name** (e.g., `cr123_project`)",
+            "**Table name** (display name, e.g., \"Project Task\")",
+            "**Target environment URL** (e.g., `https://org-test.crm.dynamics.com`)",
+            "**Target table** logical name and entity set name",
+            "**What data** they want to retrieve (which table, which columns)",
+            "Type-specific properties:"
+          ]
+        }
+      }
+    },
+    "powerbi-fabric": {
+      "category": "analytics",
+      "description": "Generate DAX measures, Power Query M code, manage workspaces via REST API, scaffold PBIP projects, and integrate with Microsoft Fabric.",
+      "files": {
+        "manifest": "powerbi-fabric/.claude-plugin/plugin.json",
+        "readme": "powerbi-fabric/README.md",
+        "skills": [
+          "powerbi-fabric/skills/powerbi-analytics/SKILL.md"
+        ],
+        "commands": [
+          "powerbi-fabric/commands/pbi-dataset-refresh.md",
+          "powerbi-fabric/commands/pbi-direct-lake-model.md",
+          "powerbi-fabric/commands/pbi-fabric-notebook.md",
+          "powerbi-fabric/commands/pbi-fabric-pipeline.md",
+          "powerbi-fabric/commands/pbi-measure.md",
+          "powerbi-fabric/commands/pbi-query.md",
+          "powerbi-fabric/commands/pbi-scaffold.md",
+          "powerbi-fabric/commands/pbi-workspace-create.md",
+          "powerbi-fabric/commands/setup.md"
+        ],
+        "agents": [
+          "powerbi-fabric/agents/dax-reviewer.md"
+        ]
+      },
+      "domains": {
+        "DAX Measures": {
+          "actions": [
+            {
+              "name": "pbi-dataset-refresh",
+              "description": "Generate TypeScript code to trigger a Power BI dataset refresh and poll for completion status via the REST API.",
+              "source": "powerbi-fabric/commands/pbi-dataset-refresh.md"
+            },
+            {
+              "name": "pbi-direct-lake-model",
+              "description": "Generate TMDL for a Direct Lake semantic model over a Fabric Lakehouse",
+              "source": "powerbi-fabric/commands/pbi-direct-lake-model.md"
+            },
+            {
+              "name": "pbi-fabric-notebook",
+              "description": "Generate a Microsoft Fabric notebook (PySpark) for data transformation with Lakehouse integration. Outputs Python cells for reading, transforming, and writing Delta tables.",
+              "source": "powerbi-fabric/commands/pbi-fabric-notebook.md"
+            },
+            {
+              "name": "pbi-fabric-pipeline",
+              "description": "Scaffold a Fabric Data Pipeline JSON definition with Copy and Notebook activities",
+              "source": "powerbi-fabric/commands/pbi-fabric-pipeline.md"
+            },
+            {
+              "name": "pbi-measure",
+              "description": "Generate a DAX measure from a natural language description. Outputs in the standard header comment format with optional TMDL output for PBIP projects.",
+              "source": "powerbi-fabric/commands/pbi-measure.md"
+            },
+            {
+              "name": "pbi-query",
+              "description": "Generate Power Query M code for data transformation or source connection. Supports multiple data source types and common transformation patterns.",
+              "source": "powerbi-fabric/commands/pbi-query.md"
+            },
+            {
+              "name": "pbi-scaffold",
+              "description": "Generate a complete PBIP (Power BI Project) structure with tables, measures, relationships, and report layout. Outputs files ready for Git.",
+              "source": "powerbi-fabric/commands/pbi-scaffold.md"
+            },
+            {
+              "name": "pbi-workspace-create",
+              "description": "Generate TypeScript code to create and configure a Power BI workspace using the REST API, including user role assignments and capacity configuration.",
+              "source": "powerbi-fabric/commands/pbi-workspace-create.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Power BI / Fabric plugin — configure Azure auth, verify workspace access, and optionally set up Fabric notebook environment",
+              "source": "powerbi-fabric/commands/setup.md"
+            }
+          ],
+          "prerequisites": []
+        },
+        "Power Query M": {
+          "actions": [
+            {
+              "name": "pbi-dataset-refresh",
+              "description": "Generate TypeScript code to trigger a Power BI dataset refresh and poll for completion status via the REST API.",
+              "source": "powerbi-fabric/commands/pbi-dataset-refresh.md"
+            },
+            {
+              "name": "pbi-direct-lake-model",
+              "description": "Generate TMDL for a Direct Lake semantic model over a Fabric Lakehouse",
+              "source": "powerbi-fabric/commands/pbi-direct-lake-model.md"
+            },
+            {
+              "name": "pbi-fabric-notebook",
+              "description": "Generate a Microsoft Fabric notebook (PySpark) for data transformation with Lakehouse integration. Outputs Python cells for reading, transforming, and writing Delta tables.",
+              "source": "powerbi-fabric/commands/pbi-fabric-notebook.md"
+            },
+            {
+              "name": "pbi-fabric-pipeline",
+              "description": "Scaffold a Fabric Data Pipeline JSON definition with Copy and Notebook activities",
+              "source": "powerbi-fabric/commands/pbi-fabric-pipeline.md"
+            },
+            {
+              "name": "pbi-measure",
+              "description": "Generate a DAX measure from a natural language description. Outputs in the standard header comment format with optional TMDL output for PBIP projects.",
+              "source": "powerbi-fabric/commands/pbi-measure.md"
+            },
+            {
+              "name": "pbi-query",
+              "description": "Generate Power Query M code for data transformation or source connection. Supports multiple data source types and common transformation patterns.",
+              "source": "powerbi-fabric/commands/pbi-query.md"
+            },
+            {
+              "name": "pbi-scaffold",
+              "description": "Generate a complete PBIP (Power BI Project) structure with tables, measures, relationships, and report layout. Outputs files ready for Git.",
+              "source": "powerbi-fabric/commands/pbi-scaffold.md"
+            },
+            {
+              "name": "pbi-workspace-create",
+              "description": "Generate TypeScript code to create and configure a Power BI workspace using the REST API, including user role assignments and capacity configuration.",
+              "source": "powerbi-fabric/commands/pbi-workspace-create.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Power BI / Fabric plugin — configure Azure auth, verify workspace access, and optionally set up Fabric notebook environment",
+              "source": "powerbi-fabric/commands/setup.md"
+            }
+          ],
+          "prerequisites": []
+        },
+        "PBIP Projects": {
+          "actions": [
+            {
+              "name": "pbi-dataset-refresh",
+              "description": "Generate TypeScript code to trigger a Power BI dataset refresh and poll for completion status via the REST API.",
+              "source": "powerbi-fabric/commands/pbi-dataset-refresh.md"
+            },
+            {
+              "name": "pbi-direct-lake-model",
+              "description": "Generate TMDL for a Direct Lake semantic model over a Fabric Lakehouse",
+              "source": "powerbi-fabric/commands/pbi-direct-lake-model.md"
+            },
+            {
+              "name": "pbi-fabric-notebook",
+              "description": "Generate a Microsoft Fabric notebook (PySpark) for data transformation with Lakehouse integration. Outputs Python cells for reading, transforming, and writing Delta tables.",
+              "source": "powerbi-fabric/commands/pbi-fabric-notebook.md"
+            },
+            {
+              "name": "pbi-fabric-pipeline",
+              "description": "Scaffold a Fabric Data Pipeline JSON definition with Copy and Notebook activities",
+              "source": "powerbi-fabric/commands/pbi-fabric-pipeline.md"
+            },
+            {
+              "name": "pbi-measure",
+              "description": "Generate a DAX measure from a natural language description. Outputs in the standard header comment format with optional TMDL output for PBIP projects.",
+              "source": "powerbi-fabric/commands/pbi-measure.md"
+            },
+            {
+              "name": "pbi-query",
+              "description": "Generate Power Query M code for data transformation or source connection. Supports multiple data source types and common transformation patterns.",
+              "source": "powerbi-fabric/commands/pbi-query.md"
+            },
+            {
+              "name": "pbi-scaffold",
+              "description": "Generate a complete PBIP (Power BI Project) structure with tables, measures, relationships, and report layout. Outputs files ready for Git.",
+              "source": "powerbi-fabric/commands/pbi-scaffold.md"
+            },
+            {
+              "name": "pbi-workspace-create",
+              "description": "Generate TypeScript code to create and configure a Power BI workspace using the REST API, including user role assignments and capacity configuration.",
+              "source": "powerbi-fabric/commands/pbi-workspace-create.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Power BI / Fabric plugin — configure Azure auth, verify workspace access, and optionally set up Fabric notebook environment",
+              "source": "powerbi-fabric/commands/setup.md"
+            }
+          ],
+          "prerequisites": []
+        },
+        "REST API": {
+          "actions": [
+            {
+              "name": "pbi-dataset-refresh",
+              "description": "Generate TypeScript code to trigger a Power BI dataset refresh and poll for completion status via the REST API.",
+              "source": "powerbi-fabric/commands/pbi-dataset-refresh.md"
+            },
+            {
+              "name": "pbi-direct-lake-model",
+              "description": "Generate TMDL for a Direct Lake semantic model over a Fabric Lakehouse",
+              "source": "powerbi-fabric/commands/pbi-direct-lake-model.md"
+            },
+            {
+              "name": "pbi-fabric-notebook",
+              "description": "Generate a Microsoft Fabric notebook (PySpark) for data transformation with Lakehouse integration. Outputs Python cells for reading, transforming, and writing Delta tables.",
+              "source": "powerbi-fabric/commands/pbi-fabric-notebook.md"
+            },
+            {
+              "name": "pbi-fabric-pipeline",
+              "description": "Scaffold a Fabric Data Pipeline JSON definition with Copy and Notebook activities",
+              "source": "powerbi-fabric/commands/pbi-fabric-pipeline.md"
+            },
+            {
+              "name": "pbi-measure",
+              "description": "Generate a DAX measure from a natural language description. Outputs in the standard header comment format with optional TMDL output for PBIP projects.",
+              "source": "powerbi-fabric/commands/pbi-measure.md"
+            },
+            {
+              "name": "pbi-query",
+              "description": "Generate Power Query M code for data transformation or source connection. Supports multiple data source types and common transformation patterns.",
+              "source": "powerbi-fabric/commands/pbi-query.md"
+            },
+            {
+              "name": "pbi-scaffold",
+              "description": "Generate a complete PBIP (Power BI Project) structure with tables, measures, relationships, and report layout. Outputs files ready for Git.",
+              "source": "powerbi-fabric/commands/pbi-scaffold.md"
+            },
+            {
+              "name": "pbi-workspace-create",
+              "description": "Generate TypeScript code to create and configure a Power BI workspace using the REST API, including user role assignments and capacity configuration.",
+              "source": "powerbi-fabric/commands/pbi-workspace-create.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Power BI / Fabric plugin — configure Azure auth, verify workspace access, and optionally set up Fabric notebook environment",
+              "source": "powerbi-fabric/commands/setup.md"
+            }
+          ],
+          "prerequisites": []
+        },
+        "Fabric": {
+          "actions": [
+            {
+              "name": "pbi-dataset-refresh",
+              "description": "Generate TypeScript code to trigger a Power BI dataset refresh and poll for completion status via the REST API.",
+              "source": "powerbi-fabric/commands/pbi-dataset-refresh.md"
+            },
+            {
+              "name": "pbi-direct-lake-model",
+              "description": "Generate TMDL for a Direct Lake semantic model over a Fabric Lakehouse",
+              "source": "powerbi-fabric/commands/pbi-direct-lake-model.md"
+            },
+            {
+              "name": "pbi-fabric-notebook",
+              "description": "Generate a Microsoft Fabric notebook (PySpark) for data transformation with Lakehouse integration. Outputs Python cells for reading, transforming, and writing Delta tables.",
+              "source": "powerbi-fabric/commands/pbi-fabric-notebook.md"
+            },
+            {
+              "name": "pbi-fabric-pipeline",
+              "description": "Scaffold a Fabric Data Pipeline JSON definition with Copy and Notebook activities",
+              "source": "powerbi-fabric/commands/pbi-fabric-pipeline.md"
+            },
+            {
+              "name": "pbi-measure",
+              "description": "Generate a DAX measure from a natural language description. Outputs in the standard header comment format with optional TMDL output for PBIP projects.",
+              "source": "powerbi-fabric/commands/pbi-measure.md"
+            },
+            {
+              "name": "pbi-query",
+              "description": "Generate Power Query M code for data transformation or source connection. Supports multiple data source types and common transformation patterns.",
+              "source": "powerbi-fabric/commands/pbi-query.md"
+            },
+            {
+              "name": "pbi-scaffold",
+              "description": "Generate a complete PBIP (Power BI Project) structure with tables, measures, relationships, and report layout. Outputs files ready for Git.",
+              "source": "powerbi-fabric/commands/pbi-scaffold.md"
+            },
+            {
+              "name": "pbi-workspace-create",
+              "description": "Generate TypeScript code to create and configure a Power BI workspace using the REST API, including user role assignments and capacity configuration.",
+              "source": "powerbi-fabric/commands/pbi-workspace-create.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Power BI / Fabric plugin — configure Azure auth, verify workspace access, and optionally set up Fabric notebook environment",
+              "source": "powerbi-fabric/commands/setup.md"
+            }
+          ],
+          "prerequisites": []
+        },
+        "Review": {
+          "actions": [
+            {
+              "name": "pbi-dataset-refresh",
+              "description": "Generate TypeScript code to trigger a Power BI dataset refresh and poll for completion status via the REST API.",
+              "source": "powerbi-fabric/commands/pbi-dataset-refresh.md"
+            },
+            {
+              "name": "pbi-direct-lake-model",
+              "description": "Generate TMDL for a Direct Lake semantic model over a Fabric Lakehouse",
+              "source": "powerbi-fabric/commands/pbi-direct-lake-model.md"
+            },
+            {
+              "name": "pbi-fabric-notebook",
+              "description": "Generate a Microsoft Fabric notebook (PySpark) for data transformation with Lakehouse integration. Outputs Python cells for reading, transforming, and writing Delta tables.",
+              "source": "powerbi-fabric/commands/pbi-fabric-notebook.md"
+            },
+            {
+              "name": "pbi-fabric-pipeline",
+              "description": "Scaffold a Fabric Data Pipeline JSON definition with Copy and Notebook activities",
+              "source": "powerbi-fabric/commands/pbi-fabric-pipeline.md"
+            },
+            {
+              "name": "pbi-measure",
+              "description": "Generate a DAX measure from a natural language description. Outputs in the standard header comment format with optional TMDL output for PBIP projects.",
+              "source": "powerbi-fabric/commands/pbi-measure.md"
+            },
+            {
+              "name": "pbi-query",
+              "description": "Generate Power Query M code for data transformation or source connection. Supports multiple data source types and common transformation patterns.",
+              "source": "powerbi-fabric/commands/pbi-query.md"
+            },
+            {
+              "name": "pbi-scaffold",
+              "description": "Generate a complete PBIP (Power BI Project) structure with tables, measures, relationships, and report layout. Outputs files ready for Git.",
+              "source": "powerbi-fabric/commands/pbi-scaffold.md"
+            },
+            {
+              "name": "pbi-workspace-create",
+              "description": "Generate TypeScript code to create and configure a Power BI workspace using the REST API, including user role assignments and capacity configuration.",
+              "source": "powerbi-fabric/commands/pbi-workspace-create.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Power BI / Fabric plugin — configure Azure auth, verify workspace access, and optionally set up Fabric notebook environment",
+              "source": "powerbi-fabric/commands/setup.md"
+            }
+          ],
+          "prerequisites": []
+        },
+        "DAX & Power BI Reviewer": {
+          "actions": [
+            {
+              "name": "pbi-dataset-refresh",
+              "description": "Generate TypeScript code to trigger a Power BI dataset refresh and poll for completion status via the REST API.",
+              "source": "powerbi-fabric/commands/pbi-dataset-refresh.md"
+            },
+            {
+              "name": "pbi-direct-lake-model",
+              "description": "Generate TMDL for a Direct Lake semantic model over a Fabric Lakehouse",
+              "source": "powerbi-fabric/commands/pbi-direct-lake-model.md"
+            },
+            {
+              "name": "pbi-fabric-notebook",
+              "description": "Generate a Microsoft Fabric notebook (PySpark) for data transformation with Lakehouse integration. Outputs Python cells for reading, transforming, and writing Delta tables.",
+              "source": "powerbi-fabric/commands/pbi-fabric-notebook.md"
+            },
+            {
+              "name": "pbi-fabric-pipeline",
+              "description": "Scaffold a Fabric Data Pipeline JSON definition with Copy and Notebook activities",
+              "source": "powerbi-fabric/commands/pbi-fabric-pipeline.md"
+            },
+            {
+              "name": "pbi-measure",
+              "description": "Generate a DAX measure from a natural language description. Outputs in the standard header comment format with optional TMDL output for PBIP projects.",
+              "source": "powerbi-fabric/commands/pbi-measure.md"
+            },
+            {
+              "name": "pbi-query",
+              "description": "Generate Power Query M code for data transformation or source connection. Supports multiple data source types and common transformation patterns.",
+              "source": "powerbi-fabric/commands/pbi-query.md"
+            },
+            {
+              "name": "pbi-scaffold",
+              "description": "Generate a complete PBIP (Power BI Project) structure with tables, measures, relationships, and report layout. Outputs files ready for Git.",
+              "source": "powerbi-fabric/commands/pbi-scaffold.md"
+            },
+            {
+              "name": "pbi-workspace-create",
+              "description": "Generate TypeScript code to create and configure a Power BI workspace using the REST API, including user role assignments and capacity configuration.",
+              "source": "powerbi-fabric/commands/pbi-workspace-create.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Power BI / Fabric plugin — configure Azure auth, verify workspace access, and optionally set up Fabric notebook environment",
+              "source": "powerbi-fabric/commands/setup.md"
+            }
+          ],
+          "prerequisites": []
+        }
+      }
+    },
+    "powerplatform-alm": {
+      "category": "devops",
+      "description": "Application lifecycle management — environment provisioning, solution transport, CI/CD pipeline generation, and PCF control scaffolding.",
+      "files": {
+        "manifest": "powerplatform-alm/.claude-plugin/plugin.json",
+        "readme": "powerplatform-alm/README.md",
+        "skills": [
+          "powerplatform-alm/skills/alm-lifecycle/SKILL.md"
+        ],
+        "commands": [
+          "powerplatform-alm/commands/alm-env-create.md",
+          "powerplatform-alm/commands/alm-env-list.md",
+          "powerplatform-alm/commands/alm-envvar-set.md",
+          "powerplatform-alm/commands/alm-pcf-build.md",
+          "powerplatform-alm/commands/alm-pcf-init.md",
+          "powerplatform-alm/commands/alm-pipeline-generate.md",
+          "powerplatform-alm/commands/alm-solution-diff.md",
+          "powerplatform-alm/commands/alm-solution-export.md",
+          "powerplatform-alm/commands/alm-solution-import.md",
+          "powerplatform-alm/commands/setup.md"
+        ],
+        "agents": [
+          "powerplatform-alm/agents/alm-reviewer.md"
+        ]
+      },
+      "domains": {
+        "devops": {
+          "actions": [
+            {
+              "name": "alm-env-create",
+              "description": "Create and configure a Power Platform environment with specified settings (type, region, language, currency, security group).",
+              "source": "powerplatform-alm/commands/alm-env-create.md"
+            },
+            {
+              "name": "alm-env-list",
+              "description": "List Power Platform environments with status, URL, type, and capacity information.",
+              "source": "powerplatform-alm/commands/alm-env-list.md"
+            },
+            {
+              "name": "alm-envvar-set",
+              "description": "Set Power Platform environment variable values for a specific environment, or generate deployment settings files.",
+              "source": "powerplatform-alm/commands/alm-envvar-set.md"
+            },
+            {
+              "name": "alm-pcf-build",
+              "description": "Build a PCF control and optionally deploy it to a development environment or package it in a solution.",
+              "source": "powerplatform-alm/commands/alm-pcf-build.md"
+            },
+            {
+              "name": "alm-pcf-init",
+              "description": "Scaffold a new PCF (PowerApps Component Framework) control from template — field, dataset, or React-based.",
+              "source": "powerplatform-alm/commands/alm-pcf-init.md"
+            },
+            {
+              "name": "alm-pipeline-generate",
+              "description": "Generate CI/CD pipeline YAML for Azure DevOps or GitHub Actions to automate Power Platform solution deployment.",
+              "source": "powerplatform-alm/commands/alm-pipeline-generate.md"
+            },
+            {
+              "name": "alm-solution-diff",
+              "description": "Compare two Power Platform solutions to identify added, removed, and modified components across environments or versions.",
+              "source": "powerplatform-alm/commands/alm-solution-diff.md"
+            },
+            {
+              "name": "alm-solution-export",
+              "description": "Export a Power Platform solution as managed or unmanaged zip, with optional version setting and solution checker validation.",
+              "source": "powerplatform-alm/commands/alm-solution-export.md"
+            },
+            {
+              "name": "alm-solution-import",
+              "description": "Import a Power Platform solution with connection reference and environment variable mapping via deployment settings.",
+              "source": "powerplatform-alm/commands/alm-solution-import.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Power Platform ALM plugin — install PAC CLI, configure environments, authenticate, and optionally set up CI/CD pipelines and PCF development",
+              "source": "powerplatform-alm/commands/setup.md"
+            }
+          ],
+          "prerequisites": [
+            "**.NET SDK 6+** — run `dotnet --version` and confirm the major version is >= 6",
+            "**Node.js 18+** — run `node --version` and confirm the major version is >= 18",
+            "**PowerShell 7+** — run `pwsh --version` and confirm the major version is >= 7"
+          ]
+        }
+      }
+    },
+    "onedrive": {
+      "category": "productivity",
+      "description": "OneDrive file management via Microsoft Graph — upload, download, share, search, and delta sync for personal and business drives.",
+      "files": {
+        "manifest": "onedrive/.claude-plugin/plugin.json",
+        "readme": "onedrive/README.md",
+        "skills": [
+          "onedrive/skills/onedrive-files/SKILL.md"
+        ],
+        "commands": [
+          "onedrive/commands/onedrive-download.md",
+          "onedrive/commands/onedrive-search.md",
+          "onedrive/commands/onedrive-share.md",
+          "onedrive/commands/onedrive-sync-status.md",
+          "onedrive/commands/onedrive-upload.md",
+          "onedrive/commands/setup.md"
+        ],
+        "agents": [
+          "onedrive/agents/onedrive-reviewer.md"
+        ]
+      },
+      "domains": {
+        "File Operations": {
+          "actions": [
+            {
+              "name": "onedrive-download",
+              "description": "Download a file from OneDrive by path or item ID",
+              "source": "onedrive/commands/onedrive-download.md"
+            },
+            {
+              "name": "onedrive-search",
+              "description": "Search for files in OneDrive by name or content",
+              "source": "onedrive/commands/onedrive-search.md"
+            },
+            {
+              "name": "onedrive-share",
+              "description": "Create a sharing link for a OneDrive file or folder",
+              "source": "onedrive/commands/onedrive-share.md"
+            },
+            {
+              "name": "onedrive-sync-status",
+              "description": "Check OneDrive sync status and recent changes using delta queries",
+              "source": "onedrive/commands/onedrive-sync-status.md"
+            },
+            {
+              "name": "onedrive-upload",
+              "description": "Upload a file to OneDrive. Automatically uses resumable upload for files over 4 MB.",
+              "source": "onedrive/commands/onedrive-upload.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the OneDrive plugin — configure Azure auth, verify drive access, and test file operations",
+              "source": "onedrive/commands/setup.md"
+            }
+          ],
+          "prerequisites": []
+        },
+        "Sharing": {
+          "actions": [
+            {
+              "name": "onedrive-download",
+              "description": "Download a file from OneDrive by path or item ID",
+              "source": "onedrive/commands/onedrive-download.md"
+            },
+            {
+              "name": "onedrive-search",
+              "description": "Search for files in OneDrive by name or content",
+              "source": "onedrive/commands/onedrive-search.md"
+            },
+            {
+              "name": "onedrive-share",
+              "description": "Create a sharing link for a OneDrive file or folder",
+              "source": "onedrive/commands/onedrive-share.md"
+            },
+            {
+              "name": "onedrive-sync-status",
+              "description": "Check OneDrive sync status and recent changes using delta queries",
+              "source": "onedrive/commands/onedrive-sync-status.md"
+            },
+            {
+              "name": "onedrive-upload",
+              "description": "Upload a file to OneDrive. Automatically uses resumable upload for files over 4 MB.",
+              "source": "onedrive/commands/onedrive-upload.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the OneDrive plugin — configure Azure auth, verify drive access, and test file operations",
+              "source": "onedrive/commands/setup.md"
+            }
+          ],
+          "prerequisites": []
+        },
+        "Search": {
+          "actions": [
+            {
+              "name": "onedrive-download",
+              "description": "Download a file from OneDrive by path or item ID",
+              "source": "onedrive/commands/onedrive-download.md"
+            },
+            {
+              "name": "onedrive-search",
+              "description": "Search for files in OneDrive by name or content",
+              "source": "onedrive/commands/onedrive-search.md"
+            },
+            {
+              "name": "onedrive-share",
+              "description": "Create a sharing link for a OneDrive file or folder",
+              "source": "onedrive/commands/onedrive-share.md"
+            },
+            {
+              "name": "onedrive-sync-status",
+              "description": "Check OneDrive sync status and recent changes using delta queries",
+              "source": "onedrive/commands/onedrive-sync-status.md"
+            },
+            {
+              "name": "onedrive-upload",
+              "description": "Upload a file to OneDrive. Automatically uses resumable upload for files over 4 MB.",
+              "source": "onedrive/commands/onedrive-upload.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the OneDrive plugin — configure Azure auth, verify drive access, and test file operations",
+              "source": "onedrive/commands/setup.md"
+            }
+          ],
+          "prerequisites": []
+        },
+        "Delta Sync": {
+          "actions": [
+            {
+              "name": "onedrive-download",
+              "description": "Download a file from OneDrive by path or item ID",
+              "source": "onedrive/commands/onedrive-download.md"
+            },
+            {
+              "name": "onedrive-search",
+              "description": "Search for files in OneDrive by name or content",
+              "source": "onedrive/commands/onedrive-search.md"
+            },
+            {
+              "name": "onedrive-share",
+              "description": "Create a sharing link for a OneDrive file or folder",
+              "source": "onedrive/commands/onedrive-share.md"
+            },
+            {
+              "name": "onedrive-sync-status",
+              "description": "Check OneDrive sync status and recent changes using delta queries",
+              "source": "onedrive/commands/onedrive-sync-status.md"
+            },
+            {
+              "name": "onedrive-upload",
+              "description": "Upload a file to OneDrive. Automatically uses resumable upload for files over 4 MB.",
+              "source": "onedrive/commands/onedrive-upload.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the OneDrive plugin — configure Azure auth, verify drive access, and test file operations",
+              "source": "onedrive/commands/setup.md"
+            }
+          ],
+          "prerequisites": []
+        },
+        "Large Files": {
+          "actions": [
+            {
+              "name": "onedrive-download",
+              "description": "Download a file from OneDrive by path or item ID",
+              "source": "onedrive/commands/onedrive-download.md"
+            },
+            {
+              "name": "onedrive-search",
+              "description": "Search for files in OneDrive by name or content",
+              "source": "onedrive/commands/onedrive-search.md"
+            },
+            {
+              "name": "onedrive-share",
+              "description": "Create a sharing link for a OneDrive file or folder",
+              "source": "onedrive/commands/onedrive-share.md"
+            },
+            {
+              "name": "onedrive-sync-status",
+              "description": "Check OneDrive sync status and recent changes using delta queries",
+              "source": "onedrive/commands/onedrive-sync-status.md"
+            },
+            {
+              "name": "onedrive-upload",
+              "description": "Upload a file to OneDrive. Automatically uses resumable upload for files over 4 MB.",
+              "source": "onedrive/commands/onedrive-upload.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the OneDrive plugin — configure Azure auth, verify drive access, and test file operations",
+              "source": "onedrive/commands/setup.md"
+            }
+          ],
+          "prerequisites": []
+        },
+        "Review": {
+          "actions": [
+            {
+              "name": "onedrive-download",
+              "description": "Download a file from OneDrive by path or item ID",
+              "source": "onedrive/commands/onedrive-download.md"
+            },
+            {
+              "name": "onedrive-search",
+              "description": "Search for files in OneDrive by name or content",
+              "source": "onedrive/commands/onedrive-search.md"
+            },
+            {
+              "name": "onedrive-share",
+              "description": "Create a sharing link for a OneDrive file or folder",
+              "source": "onedrive/commands/onedrive-share.md"
+            },
+            {
+              "name": "onedrive-sync-status",
+              "description": "Check OneDrive sync status and recent changes using delta queries",
+              "source": "onedrive/commands/onedrive-sync-status.md"
+            },
+            {
+              "name": "onedrive-upload",
+              "description": "Upload a file to OneDrive. Automatically uses resumable upload for files over 4 MB.",
+              "source": "onedrive/commands/onedrive-upload.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the OneDrive plugin — configure Azure auth, verify drive access, and test file operations",
+              "source": "onedrive/commands/setup.md"
+            }
+          ],
+          "prerequisites": []
+        },
+        "OneDrive Integration Reviewer": {
+          "actions": [
+            {
+              "name": "onedrive-download",
+              "description": "Download a file from OneDrive by path or item ID",
+              "source": "onedrive/commands/onedrive-download.md"
+            },
+            {
+              "name": "onedrive-search",
+              "description": "Search for files in OneDrive by name or content",
+              "source": "onedrive/commands/onedrive-search.md"
+            },
+            {
+              "name": "onedrive-share",
+              "description": "Create a sharing link for a OneDrive file or folder",
+              "source": "onedrive/commands/onedrive-share.md"
+            },
+            {
+              "name": "onedrive-sync-status",
+              "description": "Check OneDrive sync status and recent changes using delta queries",
+              "source": "onedrive/commands/onedrive-sync-status.md"
+            },
+            {
+              "name": "onedrive-upload",
+              "description": "Upload a file to OneDrive. Automatically uses resumable upload for files over 4 MB.",
+              "source": "onedrive/commands/onedrive-upload.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the OneDrive plugin — configure Azure auth, verify drive access, and test file operations",
+              "source": "onedrive/commands/setup.md"
+            }
+          ],
+          "prerequisites": []
+        }
+      }
+    },
+    "planner-todo": {
+      "category": "productivity",
+      "description": "Task and project management via Microsoft Graph — Planner plans, buckets, tasks, assignments, and To Do lists with steps and recurrence.",
+      "files": {
+        "manifest": "planner-todo/.claude-plugin/plugin.json",
+        "readme": "planner-todo/README.md",
+        "skills": [
+          "planner-todo/skills/planner-todo/SKILL.md"
+        ],
+        "commands": [
+          "planner-todo/commands/planner-bucket-create.md",
+          "planner-todo/commands/planner-plan-create.md",
+          "planner-todo/commands/planner-task-assign.md",
+          "planner-todo/commands/planner-task-create.md",
+          "planner-todo/commands/setup.md",
+          "planner-todo/commands/todo-list-create.md",
+          "planner-todo/commands/todo-task-create.md"
+        ],
+        "agents": [
+          "planner-todo/agents/planner-reviewer.md"
+        ]
+      },
+      "domains": {
+        "Planner Plans": {
+          "actions": [
+            {
+              "name": "planner-bucket-create",
+              "description": "Create a new bucket in a Planner plan",
+              "source": "planner-todo/commands/planner-bucket-create.md"
+            },
+            {
+              "name": "planner-plan-create",
+              "description": "Create a new Planner plan with buckets for a Microsoft 365 Group",
+              "source": "planner-todo/commands/planner-plan-create.md"
+            },
+            {
+              "name": "planner-task-assign",
+              "description": "Assign or reassign a Planner task to one or more users",
+              "source": "planner-todo/commands/planner-task-assign.md"
+            },
+            {
+              "name": "planner-task-create",
+              "description": "Create a task in a Planner plan with optional assignment and due date",
+              "source": "planner-todo/commands/planner-task-create.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Planner & To Do plugin — configure Azure auth and verify Graph API access to plans and task lists",
+              "source": "planner-todo/commands/setup.md"
+            },
+            {
+              "name": "todo-list-create",
+              "description": "Create a new Microsoft To Do task list",
+              "source": "planner-todo/commands/todo-list-create.md"
+            },
+            {
+              "name": "todo-task-create",
+              "description": "Create a task in a Microsoft To Do list with optional due date and reminder",
+              "source": "planner-todo/commands/todo-task-create.md"
+            }
+          ],
+          "prerequisites": []
+        },
+        "Tasks": {
+          "actions": [
+            {
+              "name": "planner-bucket-create",
+              "description": "Create a new bucket in a Planner plan",
+              "source": "planner-todo/commands/planner-bucket-create.md"
+            },
+            {
+              "name": "planner-plan-create",
+              "description": "Create a new Planner plan with buckets for a Microsoft 365 Group",
+              "source": "planner-todo/commands/planner-plan-create.md"
+            },
+            {
+              "name": "planner-task-assign",
+              "description": "Assign or reassign a Planner task to one or more users",
+              "source": "planner-todo/commands/planner-task-assign.md"
+            },
+            {
+              "name": "planner-task-create",
+              "description": "Create a task in a Planner plan with optional assignment and due date",
+              "source": "planner-todo/commands/planner-task-create.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Planner & To Do plugin — configure Azure auth and verify Graph API access to plans and task lists",
+              "source": "planner-todo/commands/setup.md"
+            },
+            {
+              "name": "todo-list-create",
+              "description": "Create a new Microsoft To Do task list",
+              "source": "planner-todo/commands/todo-list-create.md"
+            },
+            {
+              "name": "todo-task-create",
+              "description": "Create a task in a Microsoft To Do list with optional due date and reminder",
+              "source": "planner-todo/commands/todo-task-create.md"
+            }
+          ],
+          "prerequisites": []
+        },
+        "Assignments": {
+          "actions": [
+            {
+              "name": "planner-bucket-create",
+              "description": "Create a new bucket in a Planner plan",
+              "source": "planner-todo/commands/planner-bucket-create.md"
+            },
+            {
+              "name": "planner-plan-create",
+              "description": "Create a new Planner plan with buckets for a Microsoft 365 Group",
+              "source": "planner-todo/commands/planner-plan-create.md"
+            },
+            {
+              "name": "planner-task-assign",
+              "description": "Assign or reassign a Planner task to one or more users",
+              "source": "planner-todo/commands/planner-task-assign.md"
+            },
+            {
+              "name": "planner-task-create",
+              "description": "Create a task in a Planner plan with optional assignment and due date",
+              "source": "planner-todo/commands/planner-task-create.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Planner & To Do plugin — configure Azure auth and verify Graph API access to plans and task lists",
+              "source": "planner-todo/commands/setup.md"
+            },
+            {
+              "name": "todo-list-create",
+              "description": "Create a new Microsoft To Do task list",
+              "source": "planner-todo/commands/todo-list-create.md"
+            },
+            {
+              "name": "todo-task-create",
+              "description": "Create a task in a Microsoft To Do list with optional due date and reminder",
+              "source": "planner-todo/commands/todo-task-create.md"
+            }
+          ],
+          "prerequisites": []
+        },
+        "Labels": {
+          "actions": [
+            {
+              "name": "planner-bucket-create",
+              "description": "Create a new bucket in a Planner plan",
+              "source": "planner-todo/commands/planner-bucket-create.md"
+            },
+            {
+              "name": "planner-plan-create",
+              "description": "Create a new Planner plan with buckets for a Microsoft 365 Group",
+              "source": "planner-todo/commands/planner-plan-create.md"
+            },
+            {
+              "name": "planner-task-assign",
+              "description": "Assign or reassign a Planner task to one or more users",
+              "source": "planner-todo/commands/planner-task-assign.md"
+            },
+            {
+              "name": "planner-task-create",
+              "description": "Create a task in a Planner plan with optional assignment and due date",
+              "source": "planner-todo/commands/planner-task-create.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Planner & To Do plugin — configure Azure auth and verify Graph API access to plans and task lists",
+              "source": "planner-todo/commands/setup.md"
+            },
+            {
+              "name": "todo-list-create",
+              "description": "Create a new Microsoft To Do task list",
+              "source": "planner-todo/commands/todo-list-create.md"
+            },
+            {
+              "name": "todo-task-create",
+              "description": "Create a task in a Microsoft To Do list with optional due date and reminder",
+              "source": "planner-todo/commands/todo-task-create.md"
+            }
+          ],
+          "prerequisites": []
+        },
+        "To Do Lists": {
+          "actions": [
+            {
+              "name": "planner-bucket-create",
+              "description": "Create a new bucket in a Planner plan",
+              "source": "planner-todo/commands/planner-bucket-create.md"
+            },
+            {
+              "name": "planner-plan-create",
+              "description": "Create a new Planner plan with buckets for a Microsoft 365 Group",
+              "source": "planner-todo/commands/planner-plan-create.md"
+            },
+            {
+              "name": "planner-task-assign",
+              "description": "Assign or reassign a Planner task to one or more users",
+              "source": "planner-todo/commands/planner-task-assign.md"
+            },
+            {
+              "name": "planner-task-create",
+              "description": "Create a task in a Planner plan with optional assignment and due date",
+              "source": "planner-todo/commands/planner-task-create.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Planner & To Do plugin — configure Azure auth and verify Graph API access to plans and task lists",
+              "source": "planner-todo/commands/setup.md"
+            },
+            {
+              "name": "todo-list-create",
+              "description": "Create a new Microsoft To Do task list",
+              "source": "planner-todo/commands/todo-list-create.md"
+            },
+            {
+              "name": "todo-task-create",
+              "description": "Create a task in a Microsoft To Do list with optional due date and reminder",
+              "source": "planner-todo/commands/todo-task-create.md"
+            }
+          ],
+          "prerequisites": []
+        },
+        "Review": {
+          "actions": [
+            {
+              "name": "planner-bucket-create",
+              "description": "Create a new bucket in a Planner plan",
+              "source": "planner-todo/commands/planner-bucket-create.md"
+            },
+            {
+              "name": "planner-plan-create",
+              "description": "Create a new Planner plan with buckets for a Microsoft 365 Group",
+              "source": "planner-todo/commands/planner-plan-create.md"
+            },
+            {
+              "name": "planner-task-assign",
+              "description": "Assign or reassign a Planner task to one or more users",
+              "source": "planner-todo/commands/planner-task-assign.md"
+            },
+            {
+              "name": "planner-task-create",
+              "description": "Create a task in a Planner plan with optional assignment and due date",
+              "source": "planner-todo/commands/planner-task-create.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Planner & To Do plugin — configure Azure auth and verify Graph API access to plans and task lists",
+              "source": "planner-todo/commands/setup.md"
+            },
+            {
+              "name": "todo-list-create",
+              "description": "Create a new Microsoft To Do task list",
+              "source": "planner-todo/commands/todo-list-create.md"
+            },
+            {
+              "name": "todo-task-create",
+              "description": "Create a task in a Microsoft To Do list with optional due date and reminder",
+              "source": "planner-todo/commands/todo-task-create.md"
+            }
+          ],
+          "prerequisites": []
+        },
+        "Planner & To Do Reviewer": {
+          "actions": [
+            {
+              "name": "planner-bucket-create",
+              "description": "Create a new bucket in a Planner plan",
+              "source": "planner-todo/commands/planner-bucket-create.md"
+            },
+            {
+              "name": "planner-plan-create",
+              "description": "Create a new Planner plan with buckets for a Microsoft 365 Group",
+              "source": "planner-todo/commands/planner-plan-create.md"
+            },
+            {
+              "name": "planner-task-assign",
+              "description": "Assign or reassign a Planner task to one or more users",
+              "source": "planner-todo/commands/planner-task-assign.md"
+            },
+            {
+              "name": "planner-task-create",
+              "description": "Create a task in a Planner plan with optional assignment and due date",
+              "source": "planner-todo/commands/planner-task-create.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Planner & To Do plugin — configure Azure auth and verify Graph API access to plans and task lists",
+              "source": "planner-todo/commands/setup.md"
+            },
+            {
+              "name": "todo-list-create",
+              "description": "Create a new Microsoft To Do task list",
+              "source": "planner-todo/commands/todo-list-create.md"
+            },
+            {
+              "name": "todo-task-create",
+              "description": "Create a task in a Microsoft To Do list with optional due date and reminder",
+              "source": "planner-todo/commands/todo-task-create.md"
+            }
+          ],
+          "prerequisites": []
+        }
+      }
+    },
+    "azure-devops": {
+      "category": "devops",
+      "description": "Azure DevOps project management — Git repos, YAML pipelines, work items, pull requests, WIQL queries, and artifact feeds via REST API.",
+      "files": {
+        "manifest": "azure-devops/.claude-plugin/plugin.json",
+        "readme": "azure-devops/README.md",
+        "skills": [
+          "azure-devops/skills/azure-devops/SKILL.md"
+        ],
+        "commands": [
+          "azure-devops/commands/ado-build-status.md",
+          "azure-devops/commands/ado-pipeline-create.md",
+          "azure-devops/commands/ado-pr-create.md",
+          "azure-devops/commands/ado-query-workitems.md",
+          "azure-devops/commands/ado-repo-create.md",
+          "azure-devops/commands/ado-workitem-create.md",
+          "azure-devops/commands/setup.md"
+        ],
+        "agents": [
+          "azure-devops/agents/devops-reviewer.md"
+        ]
+      },
+      "domains": {
+        "Repositories": {
+          "actions": [
+            {
+              "name": "ado-build-status",
+              "description": "Check the status of recent pipeline builds",
+              "source": "azure-devops/commands/ado-build-status.md"
+            },
+            {
+              "name": "ado-pipeline-create",
+              "description": "Generate a YAML pipeline definition for an Azure DevOps project",
+              "source": "azure-devops/commands/ado-pipeline-create.md"
+            },
+            {
+              "name": "ado-pr-create",
+              "description": "Create a pull request in an Azure DevOps repository",
+              "source": "azure-devops/commands/ado-pr-create.md"
+            },
+            {
+              "name": "ado-query-workitems",
+              "description": "Query work items using WIQL (Work Item Query Language)",
+              "source": "azure-devops/commands/ado-query-workitems.md"
+            },
+            {
+              "name": "ado-repo-create",
+              "description": "Create a new Git repository in an Azure DevOps project",
+              "source": "azure-devops/commands/ado-repo-create.md"
+            },
+            {
+              "name": "ado-workitem-create",
+              "description": "Create a work item (User Story, Bug, Task) in Azure DevOps",
+              "source": "azure-devops/commands/ado-workitem-create.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Azure DevOps plugin — configure PAT or OAuth, verify organization and project access",
+              "source": "azure-devops/commands/setup.md"
+            }
+          ],
+          "prerequisites": [
+            "Collect Tenant ID, Client ID, Client Secret.",
+            "Guide them to Azure DevOps > User Settings > Personal Access Tokens.",
+            "Recommend scopes: `Code (Read & Write)`, `Build (Read & Execute)`, `Work Items (Read & Write)`.",
+            "Register an app with scope `499b84ac-1321-427f-aa17-267ca6975798/.default`."
+          ]
+        },
+        "Pipelines": {
+          "actions": [
+            {
+              "name": "ado-build-status",
+              "description": "Check the status of recent pipeline builds",
+              "source": "azure-devops/commands/ado-build-status.md"
+            },
+            {
+              "name": "ado-pipeline-create",
+              "description": "Generate a YAML pipeline definition for an Azure DevOps project",
+              "source": "azure-devops/commands/ado-pipeline-create.md"
+            },
+            {
+              "name": "ado-pr-create",
+              "description": "Create a pull request in an Azure DevOps repository",
+              "source": "azure-devops/commands/ado-pr-create.md"
+            },
+            {
+              "name": "ado-query-workitems",
+              "description": "Query work items using WIQL (Work Item Query Language)",
+              "source": "azure-devops/commands/ado-query-workitems.md"
+            },
+            {
+              "name": "ado-repo-create",
+              "description": "Create a new Git repository in an Azure DevOps project",
+              "source": "azure-devops/commands/ado-repo-create.md"
+            },
+            {
+              "name": "ado-workitem-create",
+              "description": "Create a work item (User Story, Bug, Task) in Azure DevOps",
+              "source": "azure-devops/commands/ado-workitem-create.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Azure DevOps plugin — configure PAT or OAuth, verify organization and project access",
+              "source": "azure-devops/commands/setup.md"
+            }
+          ],
+          "prerequisites": [
+            "Collect Tenant ID, Client ID, Client Secret.",
+            "Guide them to Azure DevOps > User Settings > Personal Access Tokens.",
+            "Recommend scopes: `Code (Read & Write)`, `Build (Read & Execute)`, `Work Items (Read & Write)`.",
+            "Register an app with scope `499b84ac-1321-427f-aa17-267ca6975798/.default`."
+          ]
+        },
+        "Work Items": {
+          "actions": [
+            {
+              "name": "ado-build-status",
+              "description": "Check the status of recent pipeline builds",
+              "source": "azure-devops/commands/ado-build-status.md"
+            },
+            {
+              "name": "ado-pipeline-create",
+              "description": "Generate a YAML pipeline definition for an Azure DevOps project",
+              "source": "azure-devops/commands/ado-pipeline-create.md"
+            },
+            {
+              "name": "ado-pr-create",
+              "description": "Create a pull request in an Azure DevOps repository",
+              "source": "azure-devops/commands/ado-pr-create.md"
+            },
+            {
+              "name": "ado-query-workitems",
+              "description": "Query work items using WIQL (Work Item Query Language)",
+              "source": "azure-devops/commands/ado-query-workitems.md"
+            },
+            {
+              "name": "ado-repo-create",
+              "description": "Create a new Git repository in an Azure DevOps project",
+              "source": "azure-devops/commands/ado-repo-create.md"
+            },
+            {
+              "name": "ado-workitem-create",
+              "description": "Create a work item (User Story, Bug, Task) in Azure DevOps",
+              "source": "azure-devops/commands/ado-workitem-create.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Azure DevOps plugin — configure PAT or OAuth, verify organization and project access",
+              "source": "azure-devops/commands/setup.md"
+            }
+          ],
+          "prerequisites": [
+            "Collect Tenant ID, Client ID, Client Secret.",
+            "Guide them to Azure DevOps > User Settings > Personal Access Tokens.",
+            "Recommend scopes: `Code (Read & Write)`, `Build (Read & Execute)`, `Work Items (Read & Write)`.",
+            "Register an app with scope `499b84ac-1321-427f-aa17-267ca6975798/.default`."
+          ]
+        },
+        "Pull Requests": {
+          "actions": [
+            {
+              "name": "ado-build-status",
+              "description": "Check the status of recent pipeline builds",
+              "source": "azure-devops/commands/ado-build-status.md"
+            },
+            {
+              "name": "ado-pipeline-create",
+              "description": "Generate a YAML pipeline definition for an Azure DevOps project",
+              "source": "azure-devops/commands/ado-pipeline-create.md"
+            },
+            {
+              "name": "ado-pr-create",
+              "description": "Create a pull request in an Azure DevOps repository",
+              "source": "azure-devops/commands/ado-pr-create.md"
+            },
+            {
+              "name": "ado-query-workitems",
+              "description": "Query work items using WIQL (Work Item Query Language)",
+              "source": "azure-devops/commands/ado-query-workitems.md"
+            },
+            {
+              "name": "ado-repo-create",
+              "description": "Create a new Git repository in an Azure DevOps project",
+              "source": "azure-devops/commands/ado-repo-create.md"
+            },
+            {
+              "name": "ado-workitem-create",
+              "description": "Create a work item (User Story, Bug, Task) in Azure DevOps",
+              "source": "azure-devops/commands/ado-workitem-create.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Azure DevOps plugin — configure PAT or OAuth, verify organization and project access",
+              "source": "azure-devops/commands/setup.md"
+            }
+          ],
+          "prerequisites": [
+            "Collect Tenant ID, Client ID, Client Secret.",
+            "Guide them to Azure DevOps > User Settings > Personal Access Tokens.",
+            "Recommend scopes: `Code (Read & Write)`, `Build (Read & Execute)`, `Work Items (Read & Write)`.",
+            "Register an app with scope `499b84ac-1321-427f-aa17-267ca6975798/.default`."
+          ]
+        },
+        "WIQL": {
+          "actions": [
+            {
+              "name": "ado-build-status",
+              "description": "Check the status of recent pipeline builds",
+              "source": "azure-devops/commands/ado-build-status.md"
+            },
+            {
+              "name": "ado-pipeline-create",
+              "description": "Generate a YAML pipeline definition for an Azure DevOps project",
+              "source": "azure-devops/commands/ado-pipeline-create.md"
+            },
+            {
+              "name": "ado-pr-create",
+              "description": "Create a pull request in an Azure DevOps repository",
+              "source": "azure-devops/commands/ado-pr-create.md"
+            },
+            {
+              "name": "ado-query-workitems",
+              "description": "Query work items using WIQL (Work Item Query Language)",
+              "source": "azure-devops/commands/ado-query-workitems.md"
+            },
+            {
+              "name": "ado-repo-create",
+              "description": "Create a new Git repository in an Azure DevOps project",
+              "source": "azure-devops/commands/ado-repo-create.md"
+            },
+            {
+              "name": "ado-workitem-create",
+              "description": "Create a work item (User Story, Bug, Task) in Azure DevOps",
+              "source": "azure-devops/commands/ado-workitem-create.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Azure DevOps plugin — configure PAT or OAuth, verify organization and project access",
+              "source": "azure-devops/commands/setup.md"
+            }
+          ],
+          "prerequisites": [
+            "Collect Tenant ID, Client ID, Client Secret.",
+            "Guide them to Azure DevOps > User Settings > Personal Access Tokens.",
+            "Recommend scopes: `Code (Read & Write)`, `Build (Read & Execute)`, `Work Items (Read & Write)`.",
+            "Register an app with scope `499b84ac-1321-427f-aa17-267ca6975798/.default`."
+          ]
+        },
+        "Artifacts": {
+          "actions": [
+            {
+              "name": "ado-build-status",
+              "description": "Check the status of recent pipeline builds",
+              "source": "azure-devops/commands/ado-build-status.md"
+            },
+            {
+              "name": "ado-pipeline-create",
+              "description": "Generate a YAML pipeline definition for an Azure DevOps project",
+              "source": "azure-devops/commands/ado-pipeline-create.md"
+            },
+            {
+              "name": "ado-pr-create",
+              "description": "Create a pull request in an Azure DevOps repository",
+              "source": "azure-devops/commands/ado-pr-create.md"
+            },
+            {
+              "name": "ado-query-workitems",
+              "description": "Query work items using WIQL (Work Item Query Language)",
+              "source": "azure-devops/commands/ado-query-workitems.md"
+            },
+            {
+              "name": "ado-repo-create",
+              "description": "Create a new Git repository in an Azure DevOps project",
+              "source": "azure-devops/commands/ado-repo-create.md"
+            },
+            {
+              "name": "ado-workitem-create",
+              "description": "Create a work item (User Story, Bug, Task) in Azure DevOps",
+              "source": "azure-devops/commands/ado-workitem-create.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Azure DevOps plugin — configure PAT or OAuth, verify organization and project access",
+              "source": "azure-devops/commands/setup.md"
+            }
+          ],
+          "prerequisites": [
+            "Collect Tenant ID, Client ID, Client Secret.",
+            "Guide them to Azure DevOps > User Settings > Personal Access Tokens.",
+            "Recommend scopes: `Code (Read & Write)`, `Build (Read & Execute)`, `Work Items (Read & Write)`.",
+            "Register an app with scope `499b84ac-1321-427f-aa17-267ca6975798/.default`."
+          ]
+        },
+        "Review": {
+          "actions": [
+            {
+              "name": "ado-build-status",
+              "description": "Check the status of recent pipeline builds",
+              "source": "azure-devops/commands/ado-build-status.md"
+            },
+            {
+              "name": "ado-pipeline-create",
+              "description": "Generate a YAML pipeline definition for an Azure DevOps project",
+              "source": "azure-devops/commands/ado-pipeline-create.md"
+            },
+            {
+              "name": "ado-pr-create",
+              "description": "Create a pull request in an Azure DevOps repository",
+              "source": "azure-devops/commands/ado-pr-create.md"
+            },
+            {
+              "name": "ado-query-workitems",
+              "description": "Query work items using WIQL (Work Item Query Language)",
+              "source": "azure-devops/commands/ado-query-workitems.md"
+            },
+            {
+              "name": "ado-repo-create",
+              "description": "Create a new Git repository in an Azure DevOps project",
+              "source": "azure-devops/commands/ado-repo-create.md"
+            },
+            {
+              "name": "ado-workitem-create",
+              "description": "Create a work item (User Story, Bug, Task) in Azure DevOps",
+              "source": "azure-devops/commands/ado-workitem-create.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Azure DevOps plugin — configure PAT or OAuth, verify organization and project access",
+              "source": "azure-devops/commands/setup.md"
+            }
+          ],
+          "prerequisites": [
+            "Collect Tenant ID, Client ID, Client Secret.",
+            "Guide them to Azure DevOps > User Settings > Personal Access Tokens.",
+            "Recommend scopes: `Code (Read & Write)`, `Build (Read & Execute)`, `Work Items (Read & Write)`.",
+            "Register an app with scope `499b84ac-1321-427f-aa17-267ca6975798/.default`."
+          ]
+        },
+        "Azure DevOps Reviewer": {
+          "actions": [
+            {
+              "name": "ado-build-status",
+              "description": "Check the status of recent pipeline builds",
+              "source": "azure-devops/commands/ado-build-status.md"
+            },
+            {
+              "name": "ado-pipeline-create",
+              "description": "Generate a YAML pipeline definition for an Azure DevOps project",
+              "source": "azure-devops/commands/ado-pipeline-create.md"
+            },
+            {
+              "name": "ado-pr-create",
+              "description": "Create a pull request in an Azure DevOps repository",
+              "source": "azure-devops/commands/ado-pr-create.md"
+            },
+            {
+              "name": "ado-query-workitems",
+              "description": "Query work items using WIQL (Work Item Query Language)",
+              "source": "azure-devops/commands/ado-query-workitems.md"
+            },
+            {
+              "name": "ado-repo-create",
+              "description": "Create a new Git repository in an Azure DevOps project",
+              "source": "azure-devops/commands/ado-repo-create.md"
+            },
+            {
+              "name": "ado-workitem-create",
+              "description": "Create a work item (User Story, Bug, Task) in Azure DevOps",
+              "source": "azure-devops/commands/ado-workitem-create.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Azure DevOps plugin — configure PAT or OAuth, verify organization and project access",
+              "source": "azure-devops/commands/setup.md"
+            }
+          ],
+          "prerequisites": [
+            "Collect Tenant ID, Client ID, Client Secret.",
+            "Guide them to Azure DevOps > User Settings > Personal Access Tokens.",
+            "Recommend scopes: `Code (Read & Write)`, `Build (Read & Execute)`, `Work Items (Read & Write)`.",
+            "Register an app with scope `499b84ac-1321-427f-aa17-267ca6975798/.default`."
+          ]
+        }
+      }
+    },
+    "entra-id-security": {
+      "category": "security",
+      "description": "Microsoft Entra ID identity governance — app registrations, service principals, conditional access policies, sign-in log analysis, and risk detection.",
+      "files": {
+        "manifest": "entra-id-security/.claude-plugin/plugin.json",
+        "readme": "entra-id-security/README.md",
+        "skills": [
+          "entra-id-security/skills/entra-security/SKILL.md"
+        ],
+        "commands": [
+          "entra-id-security/commands/entra-app-register.md",
+          "entra-id-security/commands/entra-ca-policy-create.md",
+          "entra-id-security/commands/entra-ca-wizard.md",
+          "entra-id-security/commands/entra-permissions-audit.md",
+          "entra-id-security/commands/entra-risky-users.md",
+          "entra-id-security/commands/entra-signin-logs.md",
+          "entra-id-security/commands/entra-sp-create.md",
+          "entra-id-security/commands/setup.md"
+        ],
+        "agents": [
+          "entra-id-security/agents/entra-security-reviewer.md"
+        ]
+      },
+      "domains": {
+        "App Registrations": {
+          "actions": [
+            {
+              "name": "entra-app-register",
+              "description": "Register a new application in Microsoft Entra ID with best-practice security defaults",
+              "source": "entra-id-security/commands/entra-app-register.md"
+            },
+            {
+              "name": "entra-ca-policy-create",
+              "description": "Create a conditional access policy in report-only mode",
+              "source": "entra-id-security/commands/entra-ca-policy-create.md"
+            },
+            {
+              "name": "entra-ca-wizard",
+              "description": "Plain-language Conditional Access policy builder — describe what you want in everyday words, simulate impact, and generate a rollback plan before applying.",
+              "source": "entra-id-security/commands/entra-ca-wizard.md"
+            },
+            {
+              "name": "entra-permissions-audit",
+              "description": "Audit OAuth2 permission grants and app role assignments across the tenant",
+              "source": "entra-id-security/commands/entra-permissions-audit.md"
+            },
+            {
+              "name": "entra-risky-users",
+              "description": "List and manage risky users detected by Entra ID Protection",
+              "source": "entra-id-security/commands/entra-risky-users.md"
+            },
+            {
+              "name": "entra-signin-logs",
+              "description": "Query and analyze Microsoft Entra ID sign-in logs",
+              "source": "entra-id-security/commands/entra-signin-logs.md"
+            },
+            {
+              "name": "entra-sp-create",
+              "description": "Create a service principal for an existing app registration",
+              "source": "entra-id-security/commands/entra-sp-create.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Entra ID Security plugin — configure Azure auth with identity and security Graph API permissions",
+              "source": "entra-id-security/commands/setup.md"
+            }
+          ],
+          "prerequisites": []
+        },
+        "Service Principals": {
+          "actions": [
+            {
+              "name": "entra-app-register",
+              "description": "Register a new application in Microsoft Entra ID with best-practice security defaults",
+              "source": "entra-id-security/commands/entra-app-register.md"
+            },
+            {
+              "name": "entra-ca-policy-create",
+              "description": "Create a conditional access policy in report-only mode",
+              "source": "entra-id-security/commands/entra-ca-policy-create.md"
+            },
+            {
+              "name": "entra-ca-wizard",
+              "description": "Plain-language Conditional Access policy builder — describe what you want in everyday words, simulate impact, and generate a rollback plan before applying.",
+              "source": "entra-id-security/commands/entra-ca-wizard.md"
+            },
+            {
+              "name": "entra-permissions-audit",
+              "description": "Audit OAuth2 permission grants and app role assignments across the tenant",
+              "source": "entra-id-security/commands/entra-permissions-audit.md"
+            },
+            {
+              "name": "entra-risky-users",
+              "description": "List and manage risky users detected by Entra ID Protection",
+              "source": "entra-id-security/commands/entra-risky-users.md"
+            },
+            {
+              "name": "entra-signin-logs",
+              "description": "Query and analyze Microsoft Entra ID sign-in logs",
+              "source": "entra-id-security/commands/entra-signin-logs.md"
+            },
+            {
+              "name": "entra-sp-create",
+              "description": "Create a service principal for an existing app registration",
+              "source": "entra-id-security/commands/entra-sp-create.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Entra ID Security plugin — configure Azure auth with identity and security Graph API permissions",
+              "source": "entra-id-security/commands/setup.md"
+            }
+          ],
+          "prerequisites": []
+        },
+        "Conditional Access": {
+          "actions": [
+            {
+              "name": "entra-app-register",
+              "description": "Register a new application in Microsoft Entra ID with best-practice security defaults",
+              "source": "entra-id-security/commands/entra-app-register.md"
+            },
+            {
+              "name": "entra-ca-policy-create",
+              "description": "Create a conditional access policy in report-only mode",
+              "source": "entra-id-security/commands/entra-ca-policy-create.md"
+            },
+            {
+              "name": "entra-ca-wizard",
+              "description": "Plain-language Conditional Access policy builder — describe what you want in everyday words, simulate impact, and generate a rollback plan before applying.",
+              "source": "entra-id-security/commands/entra-ca-wizard.md"
+            },
+            {
+              "name": "entra-permissions-audit",
+              "description": "Audit OAuth2 permission grants and app role assignments across the tenant",
+              "source": "entra-id-security/commands/entra-permissions-audit.md"
+            },
+            {
+              "name": "entra-risky-users",
+              "description": "List and manage risky users detected by Entra ID Protection",
+              "source": "entra-id-security/commands/entra-risky-users.md"
+            },
+            {
+              "name": "entra-signin-logs",
+              "description": "Query and analyze Microsoft Entra ID sign-in logs",
+              "source": "entra-id-security/commands/entra-signin-logs.md"
+            },
+            {
+              "name": "entra-sp-create",
+              "description": "Create a service principal for an existing app registration",
+              "source": "entra-id-security/commands/entra-sp-create.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Entra ID Security plugin — configure Azure auth with identity and security Graph API permissions",
+              "source": "entra-id-security/commands/setup.md"
+            }
+          ],
+          "prerequisites": []
+        },
+        "Sign-In Logs": {
+          "actions": [
+            {
+              "name": "entra-app-register",
+              "description": "Register a new application in Microsoft Entra ID with best-practice security defaults",
+              "source": "entra-id-security/commands/entra-app-register.md"
+            },
+            {
+              "name": "entra-ca-policy-create",
+              "description": "Create a conditional access policy in report-only mode",
+              "source": "entra-id-security/commands/entra-ca-policy-create.md"
+            },
+            {
+              "name": "entra-ca-wizard",
+              "description": "Plain-language Conditional Access policy builder — describe what you want in everyday words, simulate impact, and generate a rollback plan before applying.",
+              "source": "entra-id-security/commands/entra-ca-wizard.md"
+            },
+            {
+              "name": "entra-permissions-audit",
+              "description": "Audit OAuth2 permission grants and app role assignments across the tenant",
+              "source": "entra-id-security/commands/entra-permissions-audit.md"
+            },
+            {
+              "name": "entra-risky-users",
+              "description": "List and manage risky users detected by Entra ID Protection",
+              "source": "entra-id-security/commands/entra-risky-users.md"
+            },
+            {
+              "name": "entra-signin-logs",
+              "description": "Query and analyze Microsoft Entra ID sign-in logs",
+              "source": "entra-id-security/commands/entra-signin-logs.md"
+            },
+            {
+              "name": "entra-sp-create",
+              "description": "Create a service principal for an existing app registration",
+              "source": "entra-id-security/commands/entra-sp-create.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Entra ID Security plugin — configure Azure auth with identity and security Graph API permissions",
+              "source": "entra-id-security/commands/setup.md"
+            }
+          ],
+          "prerequisites": []
+        },
+        "Risk Detection": {
+          "actions": [
+            {
+              "name": "entra-app-register",
+              "description": "Register a new application in Microsoft Entra ID with best-practice security defaults",
+              "source": "entra-id-security/commands/entra-app-register.md"
+            },
+            {
+              "name": "entra-ca-policy-create",
+              "description": "Create a conditional access policy in report-only mode",
+              "source": "entra-id-security/commands/entra-ca-policy-create.md"
+            },
+            {
+              "name": "entra-ca-wizard",
+              "description": "Plain-language Conditional Access policy builder — describe what you want in everyday words, simulate impact, and generate a rollback plan before applying.",
+              "source": "entra-id-security/commands/entra-ca-wizard.md"
+            },
+            {
+              "name": "entra-permissions-audit",
+              "description": "Audit OAuth2 permission grants and app role assignments across the tenant",
+              "source": "entra-id-security/commands/entra-permissions-audit.md"
+            },
+            {
+              "name": "entra-risky-users",
+              "description": "List and manage risky users detected by Entra ID Protection",
+              "source": "entra-id-security/commands/entra-risky-users.md"
+            },
+            {
+              "name": "entra-signin-logs",
+              "description": "Query and analyze Microsoft Entra ID sign-in logs",
+              "source": "entra-id-security/commands/entra-signin-logs.md"
+            },
+            {
+              "name": "entra-sp-create",
+              "description": "Create a service principal for an existing app registration",
+              "source": "entra-id-security/commands/entra-sp-create.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Entra ID Security plugin — configure Azure auth with identity and security Graph API permissions",
+              "source": "entra-id-security/commands/setup.md"
+            }
+          ],
+          "prerequisites": []
+        },
+        "Permission Audit": {
+          "actions": [
+            {
+              "name": "entra-app-register",
+              "description": "Register a new application in Microsoft Entra ID with best-practice security defaults",
+              "source": "entra-id-security/commands/entra-app-register.md"
+            },
+            {
+              "name": "entra-ca-policy-create",
+              "description": "Create a conditional access policy in report-only mode",
+              "source": "entra-id-security/commands/entra-ca-policy-create.md"
+            },
+            {
+              "name": "entra-ca-wizard",
+              "description": "Plain-language Conditional Access policy builder — describe what you want in everyday words, simulate impact, and generate a rollback plan before applying.",
+              "source": "entra-id-security/commands/entra-ca-wizard.md"
+            },
+            {
+              "name": "entra-permissions-audit",
+              "description": "Audit OAuth2 permission grants and app role assignments across the tenant",
+              "source": "entra-id-security/commands/entra-permissions-audit.md"
+            },
+            {
+              "name": "entra-risky-users",
+              "description": "List and manage risky users detected by Entra ID Protection",
+              "source": "entra-id-security/commands/entra-risky-users.md"
+            },
+            {
+              "name": "entra-signin-logs",
+              "description": "Query and analyze Microsoft Entra ID sign-in logs",
+              "source": "entra-id-security/commands/entra-signin-logs.md"
+            },
+            {
+              "name": "entra-sp-create",
+              "description": "Create a service principal for an existing app registration",
+              "source": "entra-id-security/commands/entra-sp-create.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Entra ID Security plugin — configure Azure auth with identity and security Graph API permissions",
+              "source": "entra-id-security/commands/setup.md"
+            }
+          ],
+          "prerequisites": []
+        },
+        "Review": {
+          "actions": [
+            {
+              "name": "entra-app-register",
+              "description": "Register a new application in Microsoft Entra ID with best-practice security defaults",
+              "source": "entra-id-security/commands/entra-app-register.md"
+            },
+            {
+              "name": "entra-ca-policy-create",
+              "description": "Create a conditional access policy in report-only mode",
+              "source": "entra-id-security/commands/entra-ca-policy-create.md"
+            },
+            {
+              "name": "entra-ca-wizard",
+              "description": "Plain-language Conditional Access policy builder — describe what you want in everyday words, simulate impact, and generate a rollback plan before applying.",
+              "source": "entra-id-security/commands/entra-ca-wizard.md"
+            },
+            {
+              "name": "entra-permissions-audit",
+              "description": "Audit OAuth2 permission grants and app role assignments across the tenant",
+              "source": "entra-id-security/commands/entra-permissions-audit.md"
+            },
+            {
+              "name": "entra-risky-users",
+              "description": "List and manage risky users detected by Entra ID Protection",
+              "source": "entra-id-security/commands/entra-risky-users.md"
+            },
+            {
+              "name": "entra-signin-logs",
+              "description": "Query and analyze Microsoft Entra ID sign-in logs",
+              "source": "entra-id-security/commands/entra-signin-logs.md"
+            },
+            {
+              "name": "entra-sp-create",
+              "description": "Create a service principal for an existing app registration",
+              "source": "entra-id-security/commands/entra-sp-create.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Entra ID Security plugin — configure Azure auth with identity and security Graph API permissions",
+              "source": "entra-id-security/commands/setup.md"
+            }
+          ],
+          "prerequisites": []
+        },
+        "Entra ID Security Reviewer": {
+          "actions": [
+            {
+              "name": "entra-app-register",
+              "description": "Register a new application in Microsoft Entra ID with best-practice security defaults",
+              "source": "entra-id-security/commands/entra-app-register.md"
+            },
+            {
+              "name": "entra-ca-policy-create",
+              "description": "Create a conditional access policy in report-only mode",
+              "source": "entra-id-security/commands/entra-ca-policy-create.md"
+            },
+            {
+              "name": "entra-ca-wizard",
+              "description": "Plain-language Conditional Access policy builder — describe what you want in everyday words, simulate impact, and generate a rollback plan before applying.",
+              "source": "entra-id-security/commands/entra-ca-wizard.md"
+            },
+            {
+              "name": "entra-permissions-audit",
+              "description": "Audit OAuth2 permission grants and app role assignments across the tenant",
+              "source": "entra-id-security/commands/entra-permissions-audit.md"
+            },
+            {
+              "name": "entra-risky-users",
+              "description": "List and manage risky users detected by Entra ID Protection",
+              "source": "entra-id-security/commands/entra-risky-users.md"
+            },
+            {
+              "name": "entra-signin-logs",
+              "description": "Query and analyze Microsoft Entra ID sign-in logs",
+              "source": "entra-id-security/commands/entra-signin-logs.md"
+            },
+            {
+              "name": "entra-sp-create",
+              "description": "Create a service principal for an existing app registration",
+              "source": "entra-id-security/commands/entra-sp-create.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Entra ID Security plugin — configure Azure auth with identity and security Graph API permissions",
+              "source": "entra-id-security/commands/setup.md"
+            }
+          ],
+          "prerequisites": []
+        }
+      }
+    },
+    "powerapps": {
+      "category": "productivity",
+      "description": "Power Apps development — canvas app Power Fx formulas, model-driven app configuration, custom connectors, component libraries, and solution checker.",
+      "files": {
+        "manifest": "powerapps/.claude-plugin/plugin.json",
+        "readme": "powerapps/README.md",
+        "skills": [
+          "powerapps/skills/powerapps-dev/SKILL.md"
+        ],
+        "commands": [
+          "powerapps/commands/pa-canvas-screen.md",
+          "powerapps/commands/pa-component-create.md",
+          "powerapps/commands/pa-connector-create.md",
+          "powerapps/commands/pa-formula.md",
+          "powerapps/commands/pa-model-driven-form.md",
+          "powerapps/commands/pa-solution-checker.md",
+          "powerapps/commands/setup.md"
+        ],
+        "agents": [
+          "powerapps/agents/powerapps-reviewer.md"
+        ]
+      },
+      "domains": {
+        "Canvas Apps": {
+          "actions": [
+            {
+              "name": "pa-canvas-screen",
+              "description": "Generate a Power Apps canvas screen with controls, data bindings, and navigation",
+              "source": "powerapps/commands/pa-canvas-screen.md"
+            },
+            {
+              "name": "pa-component-create",
+              "description": "Generate a reusable canvas component with input/output properties",
+              "source": "powerapps/commands/pa-component-create.md"
+            },
+            {
+              "name": "pa-connector-create",
+              "description": "Generate a custom connector definition (OpenAPI/Swagger) for a REST API",
+              "source": "powerapps/commands/pa-connector-create.md"
+            },
+            {
+              "name": "pa-formula",
+              "description": "Generate a Power Fx formula from a natural language description",
+              "source": "powerapps/commands/pa-formula.md"
+            },
+            {
+              "name": "pa-model-driven-form",
+              "description": "Generate a model-driven app form configuration for a Dataverse table",
+              "source": "powerapps/commands/pa-model-driven-form.md"
+            },
+            {
+              "name": "pa-solution-checker",
+              "description": "Run solution checker analysis on Power Apps components and report issues",
+              "source": "powerapps/commands/pa-solution-checker.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Power Apps plugin — configure Power Platform environment access and install development tools",
+              "source": "powerapps/commands/setup.md"
+            }
+          ],
+          "prerequisites": []
+        },
+        "Power Fx": {
+          "actions": [
+            {
+              "name": "pa-canvas-screen",
+              "description": "Generate a Power Apps canvas screen with controls, data bindings, and navigation",
+              "source": "powerapps/commands/pa-canvas-screen.md"
+            },
+            {
+              "name": "pa-component-create",
+              "description": "Generate a reusable canvas component with input/output properties",
+              "source": "powerapps/commands/pa-component-create.md"
+            },
+            {
+              "name": "pa-connector-create",
+              "description": "Generate a custom connector definition (OpenAPI/Swagger) for a REST API",
+              "source": "powerapps/commands/pa-connector-create.md"
+            },
+            {
+              "name": "pa-formula",
+              "description": "Generate a Power Fx formula from a natural language description",
+              "source": "powerapps/commands/pa-formula.md"
+            },
+            {
+              "name": "pa-model-driven-form",
+              "description": "Generate a model-driven app form configuration for a Dataverse table",
+              "source": "powerapps/commands/pa-model-driven-form.md"
+            },
+            {
+              "name": "pa-solution-checker",
+              "description": "Run solution checker analysis on Power Apps components and report issues",
+              "source": "powerapps/commands/pa-solution-checker.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Power Apps plugin — configure Power Platform environment access and install development tools",
+              "source": "powerapps/commands/setup.md"
+            }
+          ],
+          "prerequisites": []
+        },
+        "Model-Driven": {
+          "actions": [
+            {
+              "name": "pa-canvas-screen",
+              "description": "Generate a Power Apps canvas screen with controls, data bindings, and navigation",
+              "source": "powerapps/commands/pa-canvas-screen.md"
+            },
+            {
+              "name": "pa-component-create",
+              "description": "Generate a reusable canvas component with input/output properties",
+              "source": "powerapps/commands/pa-component-create.md"
+            },
+            {
+              "name": "pa-connector-create",
+              "description": "Generate a custom connector definition (OpenAPI/Swagger) for a REST API",
+              "source": "powerapps/commands/pa-connector-create.md"
+            },
+            {
+              "name": "pa-formula",
+              "description": "Generate a Power Fx formula from a natural language description",
+              "source": "powerapps/commands/pa-formula.md"
+            },
+            {
+              "name": "pa-model-driven-form",
+              "description": "Generate a model-driven app form configuration for a Dataverse table",
+              "source": "powerapps/commands/pa-model-driven-form.md"
+            },
+            {
+              "name": "pa-solution-checker",
+              "description": "Run solution checker analysis on Power Apps components and report issues",
+              "source": "powerapps/commands/pa-solution-checker.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Power Apps plugin — configure Power Platform environment access and install development tools",
+              "source": "powerapps/commands/setup.md"
+            }
+          ],
+          "prerequisites": []
+        },
+        "Custom Connectors": {
+          "actions": [
+            {
+              "name": "pa-canvas-screen",
+              "description": "Generate a Power Apps canvas screen with controls, data bindings, and navigation",
+              "source": "powerapps/commands/pa-canvas-screen.md"
+            },
+            {
+              "name": "pa-component-create",
+              "description": "Generate a reusable canvas component with input/output properties",
+              "source": "powerapps/commands/pa-component-create.md"
+            },
+            {
+              "name": "pa-connector-create",
+              "description": "Generate a custom connector definition (OpenAPI/Swagger) for a REST API",
+              "source": "powerapps/commands/pa-connector-create.md"
+            },
+            {
+              "name": "pa-formula",
+              "description": "Generate a Power Fx formula from a natural language description",
+              "source": "powerapps/commands/pa-formula.md"
+            },
+            {
+              "name": "pa-model-driven-form",
+              "description": "Generate a model-driven app form configuration for a Dataverse table",
+              "source": "powerapps/commands/pa-model-driven-form.md"
+            },
+            {
+              "name": "pa-solution-checker",
+              "description": "Run solution checker analysis on Power Apps components and report issues",
+              "source": "powerapps/commands/pa-solution-checker.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Power Apps plugin — configure Power Platform environment access and install development tools",
+              "source": "powerapps/commands/setup.md"
+            }
+          ],
+          "prerequisites": []
+        },
+        "Components": {
+          "actions": [
+            {
+              "name": "pa-canvas-screen",
+              "description": "Generate a Power Apps canvas screen with controls, data bindings, and navigation",
+              "source": "powerapps/commands/pa-canvas-screen.md"
+            },
+            {
+              "name": "pa-component-create",
+              "description": "Generate a reusable canvas component with input/output properties",
+              "source": "powerapps/commands/pa-component-create.md"
+            },
+            {
+              "name": "pa-connector-create",
+              "description": "Generate a custom connector definition (OpenAPI/Swagger) for a REST API",
+              "source": "powerapps/commands/pa-connector-create.md"
+            },
+            {
+              "name": "pa-formula",
+              "description": "Generate a Power Fx formula from a natural language description",
+              "source": "powerapps/commands/pa-formula.md"
+            },
+            {
+              "name": "pa-model-driven-form",
+              "description": "Generate a model-driven app form configuration for a Dataverse table",
+              "source": "powerapps/commands/pa-model-driven-form.md"
+            },
+            {
+              "name": "pa-solution-checker",
+              "description": "Run solution checker analysis on Power Apps components and report issues",
+              "source": "powerapps/commands/pa-solution-checker.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Power Apps plugin — configure Power Platform environment access and install development tools",
+              "source": "powerapps/commands/setup.md"
+            }
+          ],
+          "prerequisites": []
+        },
+        "Solution Checker": {
+          "actions": [
+            {
+              "name": "pa-canvas-screen",
+              "description": "Generate a Power Apps canvas screen with controls, data bindings, and navigation",
+              "source": "powerapps/commands/pa-canvas-screen.md"
+            },
+            {
+              "name": "pa-component-create",
+              "description": "Generate a reusable canvas component with input/output properties",
+              "source": "powerapps/commands/pa-component-create.md"
+            },
+            {
+              "name": "pa-connector-create",
+              "description": "Generate a custom connector definition (OpenAPI/Swagger) for a REST API",
+              "source": "powerapps/commands/pa-connector-create.md"
+            },
+            {
+              "name": "pa-formula",
+              "description": "Generate a Power Fx formula from a natural language description",
+              "source": "powerapps/commands/pa-formula.md"
+            },
+            {
+              "name": "pa-model-driven-form",
+              "description": "Generate a model-driven app form configuration for a Dataverse table",
+              "source": "powerapps/commands/pa-model-driven-form.md"
+            },
+            {
+              "name": "pa-solution-checker",
+              "description": "Run solution checker analysis on Power Apps components and report issues",
+              "source": "powerapps/commands/pa-solution-checker.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Power Apps plugin — configure Power Platform environment access and install development tools",
+              "source": "powerapps/commands/setup.md"
+            }
+          ],
+          "prerequisites": []
+        },
+        "Review": {
+          "actions": [
+            {
+              "name": "pa-canvas-screen",
+              "description": "Generate a Power Apps canvas screen with controls, data bindings, and navigation",
+              "source": "powerapps/commands/pa-canvas-screen.md"
+            },
+            {
+              "name": "pa-component-create",
+              "description": "Generate a reusable canvas component with input/output properties",
+              "source": "powerapps/commands/pa-component-create.md"
+            },
+            {
+              "name": "pa-connector-create",
+              "description": "Generate a custom connector definition (OpenAPI/Swagger) for a REST API",
+              "source": "powerapps/commands/pa-connector-create.md"
+            },
+            {
+              "name": "pa-formula",
+              "description": "Generate a Power Fx formula from a natural language description",
+              "source": "powerapps/commands/pa-formula.md"
+            },
+            {
+              "name": "pa-model-driven-form",
+              "description": "Generate a model-driven app form configuration for a Dataverse table",
+              "source": "powerapps/commands/pa-model-driven-form.md"
+            },
+            {
+              "name": "pa-solution-checker",
+              "description": "Run solution checker analysis on Power Apps components and report issues",
+              "source": "powerapps/commands/pa-solution-checker.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Power Apps plugin — configure Power Platform environment access and install development tools",
+              "source": "powerapps/commands/setup.md"
+            }
+          ],
+          "prerequisites": []
+        },
+        "Power Apps Reviewer": {
+          "actions": [
+            {
+              "name": "pa-canvas-screen",
+              "description": "Generate a Power Apps canvas screen with controls, data bindings, and navigation",
+              "source": "powerapps/commands/pa-canvas-screen.md"
+            },
+            {
+              "name": "pa-component-create",
+              "description": "Generate a reusable canvas component with input/output properties",
+              "source": "powerapps/commands/pa-component-create.md"
+            },
+            {
+              "name": "pa-connector-create",
+              "description": "Generate a custom connector definition (OpenAPI/Swagger) for a REST API",
+              "source": "powerapps/commands/pa-connector-create.md"
+            },
+            {
+              "name": "pa-formula",
+              "description": "Generate a Power Fx formula from a natural language description",
+              "source": "powerapps/commands/pa-formula.md"
+            },
+            {
+              "name": "pa-model-driven-form",
+              "description": "Generate a model-driven app form configuration for a Dataverse table",
+              "source": "powerapps/commands/pa-model-driven-form.md"
+            },
+            {
+              "name": "pa-solution-checker",
+              "description": "Run solution checker analysis on Power Apps components and report issues",
+              "source": "powerapps/commands/pa-solution-checker.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Power Apps plugin — configure Power Platform environment access and install development tools",
+              "source": "powerapps/commands/setup.md"
+            }
+          ],
+          "prerequisites": []
+        }
+      }
+    },
+    "azure-cost-governance": {
+      "category": "cloud",
+      "description": "Azure FinOps and governance workflows — query costs, monitor budgets, detect anomalies, and identify idle resources for optimization.",
+      "files": {
+        "manifest": "azure-cost-governance/.claude-plugin/plugin.json",
+        "readme": "azure-cost-governance/README.md",
+        "skills": [
+          "azure-cost-governance/skills/azure-cost-governance/SKILL.md"
+        ],
+        "commands": [
+          "azure-cost-governance/commands/azure-budget-check.md",
+          "azure-cost-governance/commands/azure-cost-query.md",
+          "azure-cost-governance/commands/azure-idle-resources.md",
+          "azure-cost-governance/commands/setup.md"
+        ],
+        "agents": [
+          "azure-cost-governance/agents/azure-cost-governance-reviewer.md"
+        ]
+      },
+      "domains": {
+        "cloud": {
+          "actions": [
+            {
+              "name": "azure-budget-check",
+              "description": "Assess Azure budget health, forecast overrun risk, and recommend practical interventions with owner-ready output.",
+              "source": "azure-cost-governance/commands/azure-budget-check.md"
+            },
+            {
+              "name": "azure-cost-query",
+              "description": "Build a deterministic Azure Cost Management query plan with scope, filters, granularity, anomaly thresholds, and a report-ready response schema.",
+              "source": "azure-cost-governance/commands/azure-cost-query.md"
+            },
+            {
+              "name": "azure-idle-resources",
+              "description": "Detect likely idle Azure resources, rank optimization actions, and include confidence plus rollback considerations.",
+              "source": "azure-cost-governance/commands/azure-idle-resources.md"
+            },
+            {
+              "name": "setup",
+              "description": "Prepare Azure cost governance analysis by confirming scope, timeframe, dimensions, and an execution plan.",
+              "source": "azure-cost-governance/commands/setup.md"
+            }
+          ],
+          "prerequisites": []
+        }
+      }
+    },
+    "power-automate": {
+      "category": "productivity",
+      "description": "Design and troubleshoot Power Automate cloud flows — trigger/action patterns, run diagnostics, retries, and deployment-safe flow definitions.",
+      "files": {
+        "manifest": "power-automate/.claude-plugin/plugin.json",
+        "readme": "power-automate/README.md",
+        "skills": [
+          "power-automate/skills/power-automate/SKILL.md"
+        ],
+        "commands": [
+          "power-automate/commands/flow-debug.md",
+          "power-automate/commands/flow-deploy-check.md",
+          "power-automate/commands/flow-design.md",
+          "power-automate/commands/setup.md"
+        ],
+        "agents": [
+          "power-automate/agents/power-automate-reviewer.md"
+        ]
+      },
+      "domains": {
+        "productivity": {
+          "actions": [
+            {
+              "name": "flow-debug",
+              "description": "Diagnose failed Power Automate runs with evidence-driven root-cause hypotheses, validation steps, and safe remediations.",
+              "source": "power-automate/commands/flow-debug.md"
+            },
+            {
+              "name": "flow-deploy-check",
+              "description": "Run a deployment readiness review for a Power Automate flow, including connection references, variables, ownership, and rollback posture.",
+              "source": "power-automate/commands/flow-deploy-check.md"
+            },
+            {
+              "name": "flow-design",
+              "description": "Design a maintainable Power Automate cloud flow with trigger, actions, control paths, retries, and idempotency guidance.",
+              "source": "power-automate/commands/flow-design.md"
+            },
+            {
+              "name": "setup",
+              "description": "Prepare Power Automate flow work by confirming environment boundaries, connectors, scale expectations, and failure handling.",
+              "source": "power-automate/commands/setup.md"
+            }
+          ],
+          "prerequisites": []
+        }
+      }
+    },
+    "purview-compliance": {
+      "category": "security",
+      "description": "Compliance and information protection guidance for Microsoft Purview — DLP, retention, sensitivity labels, and eDiscovery workflows.",
+      "files": {
+        "manifest": "purview-compliance/.claude-plugin/plugin.json",
+        "readme": "purview-compliance/README.md",
+        "skills": [
+          "purview-compliance/skills/purview-compliance/SKILL.md"
+        ],
+        "commands": [
+          "purview-compliance/commands/compliance-playbook.md",
+          "purview-compliance/commands/dlp-review.md",
+          "purview-compliance/commands/ediscovery-plan.md",
+          "purview-compliance/commands/retention-review.md",
+          "purview-compliance/commands/setup.md"
+        ],
+        "agents": [
+          "purview-compliance/agents/compliance-reviewer.md"
+        ]
+      },
+      "domains": {
+        "security": {
+          "actions": [
+            {
+              "name": "compliance-playbook",
+              "description": "Guided compliance automation — choose a scenario like \"Set up retention for HR documents\" and walk through configuration step-by-step. Produces an audit-ready change log and owner sign-off summary.",
+              "source": "purview-compliance/commands/compliance-playbook.md"
+            },
+            {
+              "name": "dlp-review",
+              "description": "Review DLP policy coverage, false-positive hotspots, and missing controls. Prioritize recommendations by risk reduction impact.",
+              "source": "purview-compliance/commands/dlp-review.md"
+            },
+            {
+              "name": "ediscovery-plan",
+              "description": "Create an eDiscovery readiness plan with custodians, data sources, legal hold approach, search strategy, and escalation paths.",
+              "source": "purview-compliance/commands/ediscovery-plan.md"
+            },
+            {
+              "name": "retention-review",
+              "description": "Evaluate retention and records coverage across workloads — identify gaps, conflicts, and operational risks in retention labels and policies.",
+              "source": "purview-compliance/commands/retention-review.md"
+            },
+            {
+              "name": "purview-setup",
+              "description": "Set up the Purview Compliance plugin — confirm regulatory context, tenant scope, workload coverage, and install Security & Compliance PowerShell module",
+              "source": "purview-compliance/commands/setup.md"
+            }
+          ],
+          "prerequisites": []
+        }
+      }
+    },
+    "azure-policy-security": {
+      "category": "security",
+      "description": "Evaluate Azure policy compliance and security posture — policy assignments, drift analysis, remediation planning, and guardrail recommendations.",
+      "files": {
+        "manifest": "azure-policy-security/.claude-plugin/plugin.json",
+        "readme": "azure-policy-security/README.md",
+        "skills": [
+          "azure-policy-security/skills/azure-policy-security/SKILL.md"
+        ],
+        "commands": [
+          "azure-policy-security/commands/drift-analysis.md",
+          "azure-policy-security/commands/policy-coverage.md",
+          "azure-policy-security/commands/remediation-plan.md",
+          "azure-policy-security/commands/setup.md"
+        ],
+        "agents": [
+          "azure-policy-security/agents/azure-policy-security-reviewer.md"
+        ]
+      },
+      "domains": {
+        "security": {
+          "actions": [
+            {
+              "name": "drift-analysis",
+              "description": "Compare current Azure Policy state to baseline and surface high-priority drift, exception aging, and enforcement regressions.",
+              "source": "azure-policy-security/commands/drift-analysis.md"
+            },
+            {
+              "name": "policy-coverage",
+              "description": "Evaluate Azure Policy assignment coverage by scope and control category, then report actionable guardrail gaps.",
+              "source": "azure-policy-security/commands/policy-coverage.md"
+            },
+            {
+              "name": "remediation-plan",
+              "description": "Build a sequenced Azure policy/security remediation plan with owner mapping, risk notes, and measurable completion criteria.",
+              "source": "azure-policy-security/commands/remediation-plan.md"
+            },
+            {
+              "name": "setup",
+              "description": "Prepare Azure policy and security posture analysis by confirming scope, baseline initiatives, severity model, and ownership.",
+              "source": "azure-policy-security/commands/setup.md"
+            }
+          ],
+          "prerequisites": []
+        }
+      }
+    },
+    "lighthouse-health": {
+      "category": "security",
+      "description": "Multi-tenant health dashboard for MSPs/CSPs — green/yellow/red scoring for security posture, MFA coverage, stale accounts, and licensing anomalies with one-click remediation plans.",
+      "files": {
+        "manifest": "lighthouse-health/.claude-plugin/plugin.json",
+        "readme": "lighthouse-health/README.md",
+        "skills": [
+          "lighthouse-health/skills/lighthouse-health/SKILL.md"
+        ],
+        "commands": [
+          "lighthouse-health/commands/lighthouse-health-scan.md",
+          "lighthouse-health/commands/lighthouse-remediation.md",
+          "lighthouse-health/commands/setup.md"
+        ],
+        "agents": [
+          "lighthouse-health/agents/lighthouse-health-reviewer.md"
+        ]
+      },
+      "domains": {
+        "security": {
+          "actions": [
+            {
+              "name": "lighthouse-health-scan",
+              "description": "Run a health scan across selected managed tenants — produces a green/yellow/red scorecard for security, MFA, stale accounts, and licensing.",
+              "source": "lighthouse-health/commands/lighthouse-health-scan.md"
+            },
+            {
+              "name": "lighthouse-remediation",
+              "description": "Generate a prioritized remediation plan from Lighthouse health scan findings — one-click \"create remediation plan\" with effort estimates and step-by-step instructions.",
+              "source": "lighthouse-health/commands/lighthouse-remediation.md"
+            },
+            {
+              "name": "lighthouse-setup",
+              "description": "Set up the Lighthouse Health plugin — verify partner tenant access, GDAP relationships, and Lighthouse API connectivity",
+              "source": "lighthouse-health/commands/setup.md"
+            }
+          ],
+          "prerequisites": [
+            "**Effort**: Quick Fix (10 minutes)",
+            "**Risk**: Legacy auth bypasses MFA and is used in 90%+ of credential attacks",
+            "**Steps**:"
+          ]
+        }
+      }
+    },
+    "license-optimizer": {
+      "category": "cloud",
+      "description": "Identify inactive and underused M365 licenses, map downgrade/upgrade candidates, estimate monthly savings, and generate multi-tenant Lighthouse reports for customer review meetings.",
+      "files": {
+        "manifest": "license-optimizer/.claude-plugin/plugin.json",
+        "readme": "license-optimizer/README.md",
+        "skills": [
+          "license-optimizer/skills/license-optimizer/SKILL.md"
+        ],
+        "commands": [
+          "license-optimizer/commands/license-report.md",
+          "license-optimizer/commands/license-scan.md",
+          "license-optimizer/commands/setup.md"
+        ],
+        "agents": [
+          "license-optimizer/agents/license-optimizer-reviewer.md"
+        ]
+      },
+      "domains": {
+        "cloud": {
+          "actions": [
+            {
+              "name": "license-report",
+              "description": "Generate a customer-facing license optimization report for review meetings — includes savings summary, recommendations, and multi-tenant Lighthouse comparison.",
+              "source": "license-optimizer/commands/license-report.md"
+            },
+            {
+              "name": "license-scan",
+              "description": "Scan for inactive and underused licenses — identify waste, map downgrade candidates, and estimate monthly savings.",
+              "source": "license-optimizer/commands/license-scan.md"
+            },
+            {
+              "name": "license-setup",
+              "description": "Set up the License Optimizer plugin — configure Graph access for license reporting and usage analytics",
+              "source": "license-optimizer/commands/setup.md"
+            }
+          ],
+          "prerequisites": [
+            "Azure AD Premium P1 (required for `signInActivity` data)",
+            "For MSPs: Active GDAP relationships with License Administrator or Global Reader roles",
+            "Graph API access with `User.Read.All`, `Directory.Read.All`, `Reports.Read.All`"
+          ]
+        }
+      }
+    },
+    "exchange-mailflow": {
+      "category": "productivity",
+      "description": "Guided 'email not received' diagnostics — message trace, transport rules, quarantine, connectors, and SPF/DKIM/DMARC checks with client-safe explanations.",
+      "files": {
+        "manifest": "exchange-mailflow/.claude-plugin/plugin.json",
+        "readme": "exchange-mailflow/README.md",
+        "skills": [
+          "exchange-mailflow/skills/exchange-mailflow/SKILL.md"
+        ],
+        "commands": [
+          "exchange-mailflow/commands/mailflow-diagnose.md",
+          "exchange-mailflow/commands/mailflow-explain.md",
+          "exchange-mailflow/commands/setup.md"
+        ],
+        "agents": [
+          "exchange-mailflow/agents/mailflow-reviewer.md"
+        ]
+      },
+      "domains": {
+        "productivity": {
+          "actions": [
+            {
+              "name": "mailflow-diagnose",
+              "description": "Guided \"email not received\" diagnosis — step-by-step checks for message trace, transport rules, quarantine, connectors, and SPF/DKIM/DMARC.",
+              "source": "exchange-mailflow/commands/mailflow-diagnose.md"
+            },
+            {
+              "name": "mailflow-explain",
+              "description": "Convert technical mail flow findings into a client-safe explanation with plain-language cause, next actions, and timeline.",
+              "source": "exchange-mailflow/commands/mailflow-explain.md"
+            },
+            {
+              "name": "mailflow-setup",
+              "description": "Set up the Exchange Mail Flow plugin — install Exchange Online Management module and verify connectivity",
+              "source": "exchange-mailflow/commands/setup.md"
+            }
+          ],
+          "prerequisites": [
+            "DKIM signing status",
+            "DMARC policy and alignment",
+            "SPF record validity"
+          ]
+        }
+      }
+    },
+    "sharing-auditor": {
+      "category": "security",
+      "description": "Audit external sharing across SharePoint and OneDrive — find overshared links, anonymous access, and stale guest users with approval-based revocation tasks.",
+      "files": {
+        "manifest": "sharing-auditor/.claude-plugin/plugin.json",
+        "readme": "sharing-auditor/README.md",
+        "skills": [
+          "sharing-auditor/skills/sharing-auditor/SKILL.md"
+        ],
+        "commands": [
+          "sharing-auditor/commands/setup.md",
+          "sharing-auditor/commands/sharing-remediate.md",
+          "sharing-auditor/commands/sharing-scan.md"
+        ],
+        "agents": [
+          "sharing-auditor/agents/sharing-auditor-reviewer.md"
+        ]
+      },
+      "domains": {
+        "security": {
+          "actions": [
+            {
+              "name": "sharing-setup",
+              "description": "Set up the Sharing Auditor plugin — configure SharePoint admin access and Graph API permissions for sharing analysis",
+              "source": "sharing-auditor/commands/setup.md"
+            },
+            {
+              "name": "sharing-remediate",
+              "description": "Generate approval-based revocation tasks for overshared links and stale guest users — safe remediation without immediate hard deletes.",
+              "source": "sharing-auditor/commands/sharing-remediate.md"
+            },
+            {
+              "name": "sharing-scan",
+              "description": "Scan SharePoint and OneDrive for overshared links, anonymous access, and stale guest users. Produces a risk-ranked sharing audit report.",
+              "source": "sharing-auditor/commands/sharing-scan.md"
+            }
+          ],
+          "prerequisites": [
+            "Graph API access with `Sites.Read.All`, `User.Read.All`",
+            "PnP PowerShell module (optional, for detailed sharing reports)",
+            "SharePoint Administrator role for site-level setting changes",
+            "`expirationDateTime` = `null` — link never expires",
+            "`hasPassword` = `false` — no password protection",
+            "`link.scope` = `anonymous` — anyone can access without sign-in",
+            "`roles` includes `write` or `owner` — edit access to external parties"
+          ]
+        }
+      }
+    },
+    "teams-lifecycle": {
+      "category": "productivity",
+      "description": "Create and archive teams with templates, enforce naming and ownership, apply sensitivity labels, and run expiration reviews — using non-technical 'project start/end' language.",
+      "files": {
+        "manifest": "teams-lifecycle/.claude-plugin/plugin.json",
+        "readme": "teams-lifecycle/README.md",
+        "skills": [
+          "teams-lifecycle/skills/teams-lifecycle/SKILL.md"
+        ],
+        "commands": [
+          "teams-lifecycle/commands/setup.md",
+          "teams-lifecycle/commands/teams-project-end.md",
+          "teams-lifecycle/commands/teams-project-start.md",
+          "teams-lifecycle/commands/teams-review.md"
+        ],
+        "agents": [
+          "teams-lifecycle/agents/teams-lifecycle-reviewer.md"
+        ]
+      },
+      "domains": {
+        "productivity": {
+          "actions": [
+            {
+              "name": "teams-lifecycle-setup",
+              "description": "Set up the Teams Lifecycle Manager — configure Teams admin access, templates, and naming policies",
+              "source": "teams-lifecycle/commands/setup.md"
+            },
+            {
+              "name": "teams-project-end",
+              "description": "End a project — archive a team with content preservation, owner notification, and expiration review. Non-technical guided wizard.",
+              "source": "teams-lifecycle/commands/teams-project-end.md"
+            },
+            {
+              "name": "teams-project-start",
+              "description": "Start a new project — create a team from a template with proper naming, ownership, and sensitivity label. Non-technical guided wizard.",
+              "source": "teams-lifecycle/commands/teams-project-start.md"
+            },
+            {
+              "name": "teams-review",
+              "description": "Audit teams for governance compliance — check ownership, activity, naming, sensitivity labels, and expiration status.",
+              "source": "teams-lifecycle/commands/teams-review.md"
+            }
+          ],
+          "prerequisites": [
+            "Graph API access with `Team.Create`, `Group.ReadWrite.All`, `Reports.Read.All`",
+            "Teams Administrator role for governance settings"
+          ]
+        }
+      }
+    },
+    "servicedesk-runbooks": {
+      "category": "productivity",
+      "description": "Guided workflows for common IT tickets — shared mailbox access, MFA reset, file recovery, and password reset with pre-checks, approval gates, and end-user verification.",
+      "files": {
+        "manifest": "servicedesk-runbooks/.claude-plugin/plugin.json",
+        "readme": "servicedesk-runbooks/README.md",
+        "skills": [
+          "servicedesk-runbooks/skills/servicedesk-runbooks/SKILL.md"
+        ],
+        "commands": [
+          "servicedesk-runbooks/commands/runbook-password-reset.md",
+          "servicedesk-runbooks/commands/runbook-recover-file.md",
+          "servicedesk-runbooks/commands/runbook-reset-mfa.md",
+          "servicedesk-runbooks/commands/runbook-shared-mailbox.md",
+          "servicedesk-runbooks/commands/setup.md"
+        ],
+        "agents": [
+          "servicedesk-runbooks/agents/servicedesk-runbooks-reviewer.md"
+        ]
+      },
+      "domains": {
+        "productivity": {
+          "actions": [
+            {
+              "name": "runbook-password-reset",
+              "description": "Reset a user's password — guided workflow with compliance checks, secure password generation, and delivery instructions.",
+              "source": "servicedesk-runbooks/commands/runbook-password-reset.md"
+            },
+            {
+              "name": "runbook-recover-file",
+              "description": "Recover a deleted file from OneDrive or SharePoint recycle bin — guided search, preview, and restore.",
+              "source": "servicedesk-runbooks/commands/runbook-recover-file.md"
+            },
+            {
+              "name": "runbook-reset-mfa",
+              "description": "Reset MFA for a user — guided workflow with identity verification, method removal, and re-registration instructions.",
+              "source": "servicedesk-runbooks/commands/runbook-reset-mfa.md"
+            },
+            {
+              "name": "runbook-shared-mailbox",
+              "description": "Grant shared mailbox access — guided workflow with pre-checks, permission type selection, and end-user notification.",
+              "source": "servicedesk-runbooks/commands/runbook-shared-mailbox.md"
+            },
+            {
+              "name": "servicedesk-setup",
+              "description": "Set up the Service Desk Runbooks plugin — configure Graph and Exchange access for common ticket workflows",
+              "source": "servicedesk-runbooks/commands/setup.md"
+            }
+          ],
+          "prerequisites": [
+            "\"Can read all emails in the mailbox\" → Full Access",
+            "\"Can send emails on behalf of the mailbox (shows 'on behalf of')\" → Send on Behalf",
+            "\"Can send emails that appear to come from the mailbox\" → Send As",
+            "Exchange Online Management module for mailbox operations",
+            "Graph API access with `User.ReadWrite.All`, `UserAuthenticationMethod.ReadWrite.All`",
+            "SharePoint access for file recovery runbooks"
+          ]
+        }
+      }
+    },
+    "microsoft-bookings": {
+      "category": "productivity",
+      "description": "Microsoft Bookings — manage appointment calendars, services, staff availability, and customer bookings via Graph API.",
+      "files": {
+        "manifest": "microsoft-bookings/.claude-plugin/plugin.json",
+        "readme": "microsoft-bookings/README.md",
+        "skills": [
+          "microsoft-bookings/skills/microsoft-bookings/SKILL.md"
+        ],
+        "commands": [
+          "microsoft-bookings/commands/bookings-availability.md",
+          "microsoft-bookings/commands/bookings-coverage-audit.md",
+          "microsoft-bookings/commands/bookings-create-service.md",
+          "microsoft-bookings/commands/bookings-upcoming.md",
+          "microsoft-bookings/commands/setup.md"
+        ],
+        "agents": [
+          "microsoft-bookings/agents/bookings-reviewer.md"
+        ]
+      },
+      "domains": {
+        "productivity": {
+          "actions": [
+            {
+              "name": "bookings-availability",
+              "description": "\"Check staff availability for a Bookings calendar\"",
+              "source": "microsoft-bookings/commands/bookings-availability.md"
+            },
+            {
+              "name": "bookings-coverage-audit",
+              "description": "\"Audit Microsoft Bookings feature coverage against official Microsoft Graph docs\"",
+              "source": "microsoft-bookings/commands/bookings-coverage-audit.md"
+            },
+            {
+              "name": "bookings-create-service",
+              "description": "\"Create a new bookable service in a Bookings calendar\"",
+              "source": "microsoft-bookings/commands/bookings-create-service.md"
+            },
+            {
+              "name": "bookings-upcoming",
+              "description": "\"List upcoming appointments for a Bookings calendar\"",
+              "source": "microsoft-bookings/commands/bookings-upcoming.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Microsoft Bookings plugin — install dependencies, configure Azure Entra app registration, and verify Graph API access",
+              "source": "microsoft-bookings/commands/setup.md"
+            }
+          ],
+          "prerequisites": [
+            "Access to Microsoft Learn docs:",
+            "Valid Microsoft Graph token with `Bookings.Read.All`."
+          ]
+        }
+      }
+    },
+    "microsoft-forms-surveys": {
+      "category": "productivity",
+      "description": "Microsoft Forms — create surveys, add questions, collect responses, and summarize results via Graph API.",
+      "files": {
+        "manifest": "microsoft-forms-surveys/.claude-plugin/plugin.json",
+        "readme": "microsoft-forms-surveys/README.md",
+        "skills": [
+          "microsoft-forms-surveys/skills/microsoft-forms-surveys/SKILL.md"
+        ],
+        "commands": [
+          "microsoft-forms-surveys/commands/forms-add-questions.md",
+          "microsoft-forms-surveys/commands/forms-coverage-audit.md",
+          "microsoft-forms-surveys/commands/forms-create.md",
+          "microsoft-forms-surveys/commands/forms-results-summary.md",
+          "microsoft-forms-surveys/commands/setup.md"
+        ],
+        "agents": [
+          "microsoft-forms-surveys/agents/forms-reviewer.md"
+        ]
+      },
+      "domains": {
+        "Forms Survey Reviewer": {
+          "actions": [
+            {
+              "name": "forms-add-questions",
+              "description": "\"Add questions to an existing Microsoft Form\"",
+              "source": "microsoft-forms-surveys/commands/forms-add-questions.md"
+            },
+            {
+              "name": "forms-coverage-audit",
+              "description": "\"Audit Microsoft Forms feature coverage against official Graph beta documentation\"",
+              "source": "microsoft-forms-surveys/commands/forms-coverage-audit.md"
+            },
+            {
+              "name": "forms-create",
+              "description": "\"Create a new Microsoft Form\"",
+              "source": "microsoft-forms-surveys/commands/forms-create.md"
+            },
+            {
+              "name": "forms-results-summary",
+              "description": "\"Summarize responses for a Microsoft Form\"",
+              "source": "microsoft-forms-surveys/commands/forms-results-summary.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Microsoft Forms Surveys plugin — configure Azure auth and verify Graph API access for forms management",
+              "source": "microsoft-forms-surveys/commands/setup.md"
+            }
+          ],
+          "prerequisites": [
+            "Review docs:",
+            "Valid Graph beta token with `Forms.Read`."
+          ]
+        }
+      }
+    },
+    "microsoft-lists-tracker": {
+      "category": "productivity",
+      "description": "Microsoft Lists — create and manage lists for process tracking, issue logs, and project trackers via Graph API.",
+      "files": {
+        "manifest": "microsoft-lists-tracker/.claude-plugin/plugin.json",
+        "readme": "microsoft-lists-tracker/README.md",
+        "skills": [
+          "microsoft-lists-tracker/skills/microsoft-lists-tracker/SKILL.md"
+        ],
+        "commands": [
+          "microsoft-lists-tracker/commands/lists-add-item.md",
+          "microsoft-lists-tracker/commands/lists-coverage-audit.md",
+          "microsoft-lists-tracker/commands/lists-create.md",
+          "microsoft-lists-tracker/commands/lists-view-filter.md",
+          "microsoft-lists-tracker/commands/setup.md"
+        ],
+        "agents": [
+          "microsoft-lists-tracker/agents/lists-reviewer.md"
+        ]
+      },
+      "domains": {
+        "Lists Tracker Reviewer": {
+          "actions": [
+            {
+              "name": "lists-add-item",
+              "description": "\"Add an item to a Microsoft List\"",
+              "source": "microsoft-lists-tracker/commands/lists-add-item.md"
+            },
+            {
+              "name": "lists-coverage-audit",
+              "description": "\"Audit Microsoft Lists feature coverage against official Graph and SharePoint docs\"",
+              "source": "microsoft-lists-tracker/commands/lists-coverage-audit.md"
+            },
+            {
+              "name": "lists-create",
+              "description": "\"Create a new Microsoft List with custom columns\"",
+              "source": "microsoft-lists-tracker/commands/lists-create.md"
+            },
+            {
+              "name": "lists-view-filter",
+              "description": "\"View and filter items in a Microsoft List\"",
+              "source": "microsoft-lists-tracker/commands/lists-view-filter.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Microsoft Lists Tracker plugin — configure Azure auth and verify Graph API access to SharePoint Lists",
+              "source": "microsoft-lists-tracker/commands/setup.md"
+            }
+          ],
+          "prerequisites": [
+            "Graph token with `Sites.Read.All`.",
+            "Review docs:"
+          ]
+        }
+      }
+    },
+    "copilot-studio-bots": {
+      "category": "productivity",
+      "description": "Copilot Studio — design bot topics, author trigger phrases, configure generative AI orchestration, and publish chatbots.",
+      "files": {
+        "manifest": "copilot-studio-bots/.claude-plugin/plugin.json",
+        "readme": "copilot-studio-bots/README.md",
+        "skills": [
+          "copilot-studio-bots/skills/copilot-studio-bots/SKILL.md"
+        ],
+        "commands": [
+          "copilot-studio-bots/commands/bot-publish.md",
+          "copilot-studio-bots/commands/bot-test-conversation.md",
+          "copilot-studio-bots/commands/bot-topic-create.md",
+          "copilot-studio-bots/commands/setup.md"
+        ],
+        "agents": [
+          "copilot-studio-bots/agents/copilot-studio-reviewer.md"
+        ]
+      },
+      "domains": {
+        "Copilot Studio Reviewer": {
+          "actions": [
+            {
+              "name": "bot-publish",
+              "description": "\"Publish a Copilot Studio bot to channels\"",
+              "source": "copilot-studio-bots/commands/bot-publish.md"
+            },
+            {
+              "name": "bot-test-conversation",
+              "description": "\"Test a bot conversation flow with sample inputs\"",
+              "source": "copilot-studio-bots/commands/bot-test-conversation.md"
+            },
+            {
+              "name": "bot-topic-create",
+              "description": "\"Create a new topic for a Copilot Studio bot\"",
+              "source": "copilot-studio-bots/commands/bot-topic-create.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Copilot Studio Bots plugin — configure Power Platform environment access, Dataverse credentials, and Direct Line token",
+              "source": "copilot-studio-bots/commands/setup.md"
+            }
+          ],
+          "prerequisites": [
+            "**Azure CLI** (optional): Useful for managing app registrations.",
+            "**Node.js 18+**: Required for scripting and API interactions.",
+            "**npm**: Comes with Node.js."
+          ]
+        }
+      }
+    },
+    "onenote-knowledge-base": {
+      "category": "productivity",
+      "description": "OneNote Knowledge Base — read, create, and search notebooks, sections, and pages via Graph API for team documentation.",
+      "files": {
+        "manifest": "onenote-knowledge-base/.claude-plugin/plugin.json",
+        "readme": "onenote-knowledge-base/README.md",
+        "skills": [
+          "onenote-knowledge-base/skills/onenote-knowledge-base/SKILL.md"
+        ],
+        "commands": [
+          "onenote-knowledge-base/commands/onenote-create-page.md",
+          "onenote-knowledge-base/commands/onenote-meeting-notes.md",
+          "onenote-knowledge-base/commands/onenote-search.md",
+          "onenote-knowledge-base/commands/setup.md"
+        ],
+        "agents": [
+          "onenote-knowledge-base/agents/onenote-reviewer.md"
+        ]
+      },
+      "domains": {
+        "OneNote Knowledge Base Reviewer": {
+          "actions": [
+            {
+              "name": "onenote-create-page",
+              "description": "\"Create a new OneNote page with HTML content\"",
+              "source": "onenote-knowledge-base/commands/onenote-create-page.md"
+            },
+            {
+              "name": "onenote-meeting-notes",
+              "description": "\"Create a structured meeting notes page from a template\"",
+              "source": "onenote-knowledge-base/commands/onenote-meeting-notes.md"
+            },
+            {
+              "name": "onenote-search",
+              "description": "\"Search OneNote pages by keyword across notebooks\"",
+              "source": "onenote-knowledge-base/commands/onenote-search.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the OneNote Knowledge Base plugin — configure Azure auth, install dependencies, and verify notebook access",
+              "source": "onenote-knowledge-base/commands/setup.md"
+            }
+          ],
+          "prerequisites": []
+        }
+      }
+    },
+    "marketplace-dev-tools": {
+      "category": "devops",
+      "description": "Research Microsoft APIs, scaffold new plugins, extend existing ones, and audit marketplace coverage gaps.",
+      "files": {
+        "manifest": "marketplace-dev-tools/.claude-plugin/plugin.json",
+        "readme": "marketplace-dev-tools/README.md",
+        "skills": [
+          "marketplace-dev-tools/skills/marketplace-research/SKILL.md"
+        ],
+        "commands": [
+          "marketplace-dev-tools/commands/audit-coverage.md",
+          "marketplace-dev-tools/commands/extend-plugin.md",
+          "marketplace-dev-tools/commands/research-service.md",
+          "marketplace-dev-tools/commands/scaffold-plugin.md"
+        ],
+        "agents": [
+          "marketplace-dev-tools/agents/research-reviewer.md"
+        ]
+      },
+      "domains": {
+        "devops": {
+          "actions": [
+            {
+              "name": "audit-coverage",
+              "description": "Audit marketplace plugin coverage against known Microsoft 365 services",
+              "source": "marketplace-dev-tools/commands/audit-coverage.md"
+            },
+            {
+              "name": "extend-plugin",
+              "description": "Add new endpoints and commands to an existing plugin",
+              "source": "marketplace-dev-tools/commands/extend-plugin.md"
+            },
+            {
+              "name": "research-service",
+              "description": "Research a Microsoft service's Graph API — endpoints, permissions, and schemas",
+              "source": "marketplace-dev-tools/commands/research-service.md"
+            },
+            {
+              "name": "scaffold-plugin",
+              "description": "Generate a complete Claude plugin from research output",
+              "source": "marketplace-dev-tools/commands/scaffold-plugin.md"
+            }
+          ],
+          "prerequisites": [
+            "**Application**: permissions for daemon/service context",
+            "**Delegated (personal Microsoft account)**: usually \"Not supported\"",
+            "**Delegated (work or school account)**: permissions for signed-in user context"
+          ]
+        }
+      }
+    },
+    "power-pages": {
+      "category": "productivity",
+      "description": "Microsoft Power Pages — sites, page templates, Liquid, web forms, table permissions, web roles, and Dataverse portal integration",
+      "files": {
+        "manifest": "power-pages/.claude-plugin/plugin.json",
+        "readme": "power-pages/README.md",
+        "skills": [
+          "power-pages/skills/power-pages/SKILL.md"
+        ],
+        "commands": [
+          "power-pages/commands/pages-permissions.md",
+          "power-pages/commands/pages-site-create.md",
+          "power-pages/commands/pages-template-apply.md",
+          "power-pages/commands/pages-webform-create.md",
+          "power-pages/commands/setup.md"
+        ],
+        "agents": [
+          "power-pages/agents/pages-reviewer.md"
+        ]
+      },
+      "domains": {
+        "productivity": {
+          "actions": [
+            {
+              "name": "pages-permissions",
+              "description": "Configure table permissions and web roles for a Power Pages entity",
+              "source": "power-pages/commands/pages-permissions.md"
+            },
+            {
+              "name": "pages-site-create",
+              "description": "Create a new Power Pages site with a home page and basic navigation",
+              "source": "power-pages/commands/pages-site-create.md"
+            },
+            {
+              "name": "pages-template-apply",
+              "description": "Create or update a web template with Liquid content",
+              "source": "power-pages/commands/pages-template-apply.md"
+            },
+            {
+              "name": "pages-webform-create",
+              "description": "Scaffold a multi-step web form for a Power Pages site",
+              "source": "power-pages/commands/pages-webform-create.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Power Pages plugin — install PAC CLI, configure Dataverse connection, and verify portal access",
+              "source": "power-pages/commands/setup.md"
+            }
+          ],
+          "prerequisites": [
+            "Install via .NET tool: `dotnet tool install --global Microsoft.PowerApps.CLI.Tool`",
+            "Or download from https://aka.ms/PowerAppsCLI"
+          ]
+        }
+      }
+    },
+    "azure-web-apps": {
+      "category": "cloud",
+      "description": "Azure App Service — create, deploy, and manage web apps, deployment slots, custom domains, and TLS certificates via ARM REST API",
+      "files": {
+        "manifest": "azure-web-apps/.claude-plugin/plugin.json",
+        "readme": "azure-web-apps/README.md",
+        "skills": [
+          "azure-web-apps/skills/azure-web-apps/SKILL.md"
+        ],
+        "commands": [
+          "azure-web-apps/commands/setup.md",
+          "azure-web-apps/commands/webapp-config.md",
+          "azure-web-apps/commands/webapp-create.md",
+          "azure-web-apps/commands/webapp-deploy.md",
+          "azure-web-apps/commands/webapp-slots.md"
+        ],
+        "agents": [
+          "azure-web-apps/agents/webapp-reviewer.md"
+        ]
+      },
+      "domains": {
+        "cloud": {
+          "actions": [
+            {
+              "name": "setup",
+              "description": "Set up the Azure Web Apps plugin — install Azure CLI, configure subscription, and verify App Service access",
+              "source": "azure-web-apps/commands/setup.md"
+            },
+            {
+              "name": "webapp-config",
+              "description": "Manage app settings, connection strings, and custom domains",
+              "source": "azure-web-apps/commands/webapp-config.md"
+            },
+            {
+              "name": "webapp-create",
+              "description": "Create an Azure Web App with an App Service Plan",
+              "source": "azure-web-apps/commands/webapp-create.md"
+            },
+            {
+              "name": "webapp-deploy",
+              "description": "Deploy code to an Azure Web App via ZIP deploy, GitHub Actions, or Docker",
+              "source": "azure-web-apps/commands/webapp-deploy.md"
+            },
+            {
+              "name": "webapp-slots",
+              "description": "Create and manage deployment slots for blue-green deployment",
+              "source": "azure-web-apps/commands/webapp-slots.md"
+            }
+          ],
+          "prerequisites": []
+        }
+      }
+    },
+    "azure-static-web-apps": {
+      "category": "cloud",
+      "description": "Azure Static Web Apps — JAMstack/SPA hosting with built-in auth, API backends, PR preview environments, and staticwebapp.config.json management",
+      "files": {
+        "manifest": "azure-static-web-apps/.claude-plugin/plugin.json",
+        "readme": "azure-static-web-apps/README.md",
+        "skills": [
+          "azure-static-web-apps/skills/azure-static-web-apps/SKILL.md"
+        ],
+        "commands": [
+          "azure-static-web-apps/commands/setup.md",
+          "azure-static-web-apps/commands/swa-api-deploy.md",
+          "azure-static-web-apps/commands/swa-auth-configure.md",
+          "azure-static-web-apps/commands/swa-config.md",
+          "azure-static-web-apps/commands/swa-create.md"
+        ],
+        "agents": [
+          "azure-static-web-apps/agents/swa-reviewer.md"
+        ]
+      },
+      "domains": {
+        "cloud": {
+          "actions": [
+            {
+              "name": "setup",
+              "description": "Set up the Azure Static Web Apps plugin — install SWA CLI, configure Azure subscription",
+              "source": "azure-static-web-apps/commands/setup.md"
+            },
+            {
+              "name": "swa-api-deploy",
+              "description": "Create and deploy a managed Functions API for the Static Web App",
+              "source": "azure-static-web-apps/commands/swa-api-deploy.md"
+            },
+            {
+              "name": "swa-auth-configure",
+              "description": "Configure authentication providers for a Static Web App",
+              "source": "azure-static-web-apps/commands/swa-auth-configure.md"
+            },
+            {
+              "name": "swa-config",
+              "description": "Generate or update staticwebapp.config.json with routes, auth, and headers",
+              "source": "azure-static-web-apps/commands/swa-config.md"
+            },
+            {
+              "name": "swa-create",
+              "description": "Create a new Azure Static Web App resource",
+              "source": "azure-static-web-apps/commands/swa-create.md"
+            }
+          ],
+          "prerequisites": []
+        }
+      }
+    },
+    "teams-app-dev": {
+      "category": "devops",
+      "description": "Custom Teams app development — Adaptive Cards, message extensions, bot handlers, tab apps, manifest authoring, and Teams Toolkit CLI workflows.",
+      "files": {
+        "manifest": "teams-app-dev/.claude-plugin/plugin.json",
+        "readme": "teams-app-dev/README.md",
+        "skills": [
+          "teams-app-dev/skills/teams-app-dev/SKILL.md"
+        ],
+        "commands": [
+          "teams-app-dev/commands/setup.md",
+          "teams-app-dev/commands/teams-adaptive-card.md",
+          "teams-app-dev/commands/teams-bot-handler.md",
+          "teams-app-dev/commands/teams-manifest.md",
+          "teams-app-dev/commands/teams-message-extension.md",
+          "teams-app-dev/commands/teams-scaffold.md",
+          "teams-app-dev/commands/teams-sideload.md"
+        ],
+        "agents": [
+          "teams-app-dev/agents/teams-app-reviewer.md"
+        ]
+      },
+      "domains": {
+        "Teams App Reviewer": {
+          "actions": [
+            {
+              "name": "setup",
+              "description": "Set up the Teams App Dev plugin — install Teams Toolkit CLI, register Azure Bot, configure BOT_ID and BOT_PASSWORD",
+              "source": "teams-app-dev/commands/setup.md"
+            },
+            {
+              "name": "teams-adaptive-card",
+              "description": "\"Generate an Adaptive Card JSON payload from a description, with optional data templating\"",
+              "source": "teams-app-dev/commands/teams-adaptive-card.md"
+            },
+            {
+              "name": "teams-bot-handler",
+              "description": "\"Generate a TeamsActivityHandler with optional state management, dialogs, and proactive messaging\"",
+              "source": "teams-app-dev/commands/teams-bot-handler.md"
+            },
+            {
+              "name": "teams-manifest",
+              "description": "\"Generate or validate a Teams app manifest (v1.17+)\"",
+              "source": "teams-app-dev/commands/teams-manifest.md"
+            },
+            {
+              "name": "teams-message-extension",
+              "description": "\"Scaffold a message extension handler (search, action, or link unfurling) with manifest fragment\"",
+              "source": "teams-app-dev/commands/teams-message-extension.md"
+            },
+            {
+              "name": "teams-scaffold",
+              "description": "\"Scaffold a new Teams app project by type (bot, tab, or message extension)\"",
+              "source": "teams-app-dev/commands/teams-scaffold.md"
+            },
+            {
+              "name": "teams-sideload",
+              "description": "\"Package and sideload a Teams app for testing\"",
+              "source": "teams-app-dev/commands/teams-sideload.md"
+            }
+          ],
+          "prerequisites": [
+            "**Node.js 18+**: Required for Teams Toolkit and Bot Framework.",
+            "**npm**: Comes with Node.js."
+          ]
+        }
+      }
+    },
+    "azure-storage": {
+      "category": "cloud",
+      "description": "Azure Storage — Blob, Queue, Table, and Files services with lifecycle policies, SAS tokens, and managed identity access",
+      "files": {
+        "manifest": "azure-storage/.claude-plugin/plugin.json",
+        "readme": "azure-storage/README.md",
+        "skills": [
+          "azure-storage/skills/azure-storage/SKILL.md"
+        ],
+        "commands": [
+          "azure-storage/commands/blob-manage.md",
+          "azure-storage/commands/queue-manage.md",
+          "azure-storage/commands/setup.md",
+          "azure-storage/commands/storage-lifecycle.md",
+          "azure-storage/commands/storage-security.md",
+          "azure-storage/commands/storage-static-website.md"
+        ],
+        "agents": [
+          "azure-storage/agents/storage-reviewer.md"
+        ]
+      },
+      "domains": {
+        "Storage Reviewer": {
+          "actions": [
+            {
+              "name": "blob-manage",
+              "description": "\"Upload, download, list, and delete blobs; configure container access and blob properties\"",
+              "source": "azure-storage/commands/blob-manage.md"
+            },
+            {
+              "name": "queue-manage",
+              "description": "\"Create queues, send and receive messages, configure poison message handling and visibility timeout\"",
+              "source": "azure-storage/commands/queue-manage.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Azure Storage plugin — install Azure CLI, create a storage account, configure network rules and managed identity",
+              "source": "azure-storage/commands/setup.md"
+            },
+            {
+              "name": "storage-lifecycle",
+              "description": "\"Create lifecycle management policies for automatic blob tiering, deletion, and immutability\"",
+              "source": "azure-storage/commands/storage-lifecycle.md"
+            },
+            {
+              "name": "storage-security",
+              "description": "\"Generate SAS tokens, audit storage access, configure RBAC roles, firewall rules, and private endpoints\"",
+              "source": "azure-storage/commands/storage-security.md"
+            },
+            {
+              "name": "storage-static-website",
+              "description": "\"Enable static website hosting on Azure Blob Storage, deploy content, and configure CDN with custom domain\"",
+              "source": "azure-storage/commands/storage-static-website.md"
+            }
+          ],
+          "prerequisites": [
+            "**Azure CLI 2.50+**: Required for storage account management.",
+            "**Node.js 18+**: Required for the Azure Storage SDKs."
+          ]
+        }
+      }
+    },
+    "azure-functions": {
+      "category": "cloud",
+      "description": "Azure Functions — triggers, bindings, Durable Functions, deployment, and local development with Azure Functions Core Tools",
+      "files": {
+        "manifest": "azure-functions/.claude-plugin/plugin.json",
+        "readme": "azure-functions/README.md",
+        "skills": [
+          "azure-functions/skills/azure-functions/SKILL.md"
+        ],
+        "commands": [
+          "azure-functions/commands/func-binding-config.md",
+          "azure-functions/commands/func-create.md",
+          "azure-functions/commands/func-deploy.md",
+          "azure-functions/commands/func-durable.md",
+          "azure-functions/commands/func-trigger-add.md",
+          "azure-functions/commands/setup.md"
+        ],
+        "agents": [
+          "azure-functions/agents/functions-reviewer.md"
+        ]
+      },
+      "domains": {
+        "Functions Reviewer": {
+          "actions": [
+            {
+              "name": "func-binding-config",
+              "description": "\"Configure input and output bindings for an Azure Function\"",
+              "source": "azure-functions/commands/func-binding-config.md"
+            },
+            {
+              "name": "func-create",
+              "description": "\"Create a new Azure Function with trigger type selection (HTTP, Timer, Blob, Queue, Service Bus, Event Grid, Cosmos DB)\"",
+              "source": "azure-functions/commands/func-create.md"
+            },
+            {
+              "name": "func-deploy",
+              "description": "\"Deploy an Azure Functions project to Azure via CLI or generate a GitHub Actions CI/CD workflow\"",
+              "source": "azure-functions/commands/func-deploy.md"
+            },
+            {
+              "name": "func-durable",
+              "description": "\"Scaffold a Durable Functions orchestration — chaining, fan-out/fan-in, human interaction, or monitoring pattern\"",
+              "source": "azure-functions/commands/func-durable.md"
+            },
+            {
+              "name": "func-trigger-add",
+              "description": "\"Add a trigger and binding to an existing Azure Function\"",
+              "source": "azure-functions/commands/func-trigger-add.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Azure Functions plugin — install Azure Functions Core Tools, Azure CLI, create Function App, configure local.settings.json",
+              "source": "azure-functions/commands/setup.md"
+            }
+          ],
+          "prerequisites": [
+            "**Node.js 18+**: Required for Azure Functions v4 runtime.",
+            "**npm**: Comes with Node.js."
+          ]
+        }
+      }
+    },
+    "azure-containers": {
+      "category": "cloud",
+      "description": "Azure Container Apps, Container Instances, and Container Registry — build, push, deploy, and scale containerized workloads",
+      "files": {
+        "manifest": "azure-containers/.claude-plugin/plugin.json",
+        "readme": "azure-containers/README.md",
+        "skills": [
+          "azure-containers/skills/azure-containers/SKILL.md"
+        ],
+        "commands": [
+          "azure-containers/commands/aci-run.md",
+          "azure-containers/commands/acr-build-push.md",
+          "azure-containers/commands/container-app-create.md",
+          "azure-containers/commands/container-app-deploy.md",
+          "azure-containers/commands/container-app-scale.md",
+          "azure-containers/commands/setup.md"
+        ],
+        "agents": [
+          "azure-containers/agents/container-reviewer.md"
+        ]
+      },
+      "domains": {
+        "Container Reviewer": {
+          "actions": [
+            {
+              "name": "aci-run",
+              "description": "\"Run a container in Azure Container Instances for quick one-off tasks or scheduled jobs\"",
+              "source": "azure-containers/commands/aci-run.md"
+            },
+            {
+              "name": "acr-build-push",
+              "description": "\"Build and push a container image to Azure Container Registry\"",
+              "source": "azure-containers/commands/acr-build-push.md"
+            },
+            {
+              "name": "container-app-create",
+              "description": "\"Create a new Azure Container App with ingress and scaling configuration\"",
+              "source": "azure-containers/commands/container-app-create.md"
+            },
+            {
+              "name": "container-app-deploy",
+              "description": "\"Deploy a new revision to a Container App and manage traffic splitting for blue-green deployments\"",
+              "source": "azure-containers/commands/container-app-deploy.md"
+            },
+            {
+              "name": "container-app-scale",
+              "description": "\"Configure KEDA-based scale rules for a Container App (HTTP, queue, custom)\"",
+              "source": "azure-containers/commands/container-app-scale.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Azure Containers plugin — install Docker, Azure CLI, create ACR and Container Apps environment",
+              "source": "azure-containers/commands/setup.md"
+            }
+          ],
+          "prerequisites": [
+            "**Azure CLI**: Required for managing Azure resources.",
+            "**Docker**: Required for building container images locally."
+          ]
+        }
+      }
+    },
+    "azure-sql-database": {
+      "category": "cloud",
+      "description": "Azure SQL Database and Cosmos DB — provisioning, schema management, query optimization, security hardening, and backup/restore",
+      "files": {
+        "manifest": "azure-sql-database/.claude-plugin/plugin.json",
+        "readme": "azure-sql-database/README.md",
+        "skills": [
+          "azure-sql-database/skills/azure-sql-database/SKILL.md"
+        ],
+        "commands": [
+          "azure-sql-database/commands/cosmos-create.md",
+          "azure-sql-database/commands/cosmos-query.md",
+          "azure-sql-database/commands/db-security-audit.md",
+          "azure-sql-database/commands/setup.md",
+          "azure-sql-database/commands/sql-create.md",
+          "azure-sql-database/commands/sql-query.md"
+        ],
+        "agents": [
+          "azure-sql-database/agents/database-reviewer.md"
+        ]
+      },
+      "domains": {
+        "Database Reviewer": {
+          "actions": [
+            {
+              "name": "cosmos-create",
+              "description": "\"Create a Cosmos DB account, database, and container with partition key strategy\"",
+              "source": "azure-sql-database/commands/cosmos-create.md"
+            },
+            {
+              "name": "cosmos-query",
+              "description": "\"Run Cosmos DB SQL queries, analyze RU consumption, and optimize query performance\"",
+              "source": "azure-sql-database/commands/cosmos-query.md"
+            },
+            {
+              "name": "db-security-audit",
+              "description": "\"Audit Azure SQL and Cosmos DB security posture — firewall rules, TDE, data masking, AAD auth, network isolation\"",
+              "source": "azure-sql-database/commands/db-security-audit.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Azure SQL Database plugin — install Azure CLI, sqlcmd, create SQL Server + database or Cosmos DB account",
+              "source": "azure-sql-database/commands/setup.md"
+            },
+            {
+              "name": "sql-create",
+              "description": "\"Create an Azure SQL database with server, firewall rules, and optional elastic pool\"",
+              "source": "azure-sql-database/commands/sql-create.md"
+            },
+            {
+              "name": "sql-query",
+              "description": "\"Run T-SQL queries against Azure SQL, analyze execution plans, and get index recommendations\"",
+              "source": "azure-sql-database/commands/sql-query.md"
+            }
+          ],
+          "prerequisites": [
+            "**Azure CLI 2.50+**: Required for resource provisioning.",
+            "**Node.js 18+**: Required for application development and Cosmos DB SDK."
+          ]
+        }
+      }
+    },
+    "azure-key-vault": {
+      "category": "security",
+      "description": "Azure Key Vault — secrets, keys, and certificates management with RBAC, rotation policies, and managed identity integration",
+      "files": {
+        "manifest": "azure-key-vault/.claude-plugin/plugin.json",
+        "readme": "azure-key-vault/README.md",
+        "skills": [
+          "azure-key-vault/skills/azure-key-vault/SKILL.md"
+        ],
+        "commands": [
+          "azure-key-vault/commands/kv-access-audit.md",
+          "azure-key-vault/commands/kv-app-integration.md",
+          "azure-key-vault/commands/kv-certificate-manage.md",
+          "azure-key-vault/commands/kv-rotation-policy.md",
+          "azure-key-vault/commands/kv-secret-manage.md",
+          "azure-key-vault/commands/setup.md"
+        ],
+        "agents": [
+          "azure-key-vault/agents/keyvault-reviewer.md"
+        ]
+      },
+      "domains": {
+        "Key Vault Reviewer": {
+          "actions": [
+            {
+              "name": "kv-access-audit",
+              "description": "\"Audit Key Vault RBAC assignments, review network rules, and check access logs\"",
+              "source": "azure-key-vault/commands/kv-access-audit.md"
+            },
+            {
+              "name": "kv-app-integration",
+              "description": "\"Configure App Service, Functions, or Container Apps to use Key Vault secrets via managed identity\"",
+              "source": "azure-key-vault/commands/kv-app-integration.md"
+            },
+            {
+              "name": "kv-certificate-manage",
+              "description": "\"Create self-signed or CA-integrated certificates, configure auto-renewal, and export\"",
+              "source": "azure-key-vault/commands/kv-certificate-manage.md"
+            },
+            {
+              "name": "kv-rotation-policy",
+              "description": "\"Set up automatic secret and key rotation with Event Grid notifications\"",
+              "source": "azure-key-vault/commands/kv-rotation-policy.md"
+            },
+            {
+              "name": "kv-secret-manage",
+              "description": "\"Create, read, update, list, and delete secrets in Azure Key Vault\"",
+              "source": "azure-key-vault/commands/kv-secret-manage.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Azure Key Vault plugin -- install Azure CLI, create a Key Vault, configure RBAC access",
+              "source": "azure-key-vault/commands/setup.md"
+            }
+          ],
+          "prerequisites": [
+            "**Azure CLI 2.50+**: Required for Key Vault management.",
+            "**Node.js 18+**: Required if using the Azure SDK for JavaScript."
+          ]
+        }
+      }
+    },
+    "azure-monitor": {
+      "category": "cloud",
+      "description": "Azure Monitor, Application Insights, and Log Analytics — metrics, alerts, KQL queries, dashboards, and diagnostic settings",
+      "files": {
+        "manifest": "azure-monitor/.claude-plugin/plugin.json",
+        "readme": "azure-monitor/README.md",
+        "skills": [
+          "azure-monitor/skills/azure-monitor/SKILL.md"
+        ],
+        "commands": [
+          "azure-monitor/commands/alert-create.md",
+          "azure-monitor/commands/appinsights-setup.md",
+          "azure-monitor/commands/dashboard-create.md",
+          "azure-monitor/commands/diagnostic-settings.md",
+          "azure-monitor/commands/kql-query.md",
+          "azure-monitor/commands/setup.md"
+        ],
+        "agents": [
+          "azure-monitor/agents/monitor-reviewer.md"
+        ]
+      },
+      "domains": {
+        "Monitor Reviewer": {
+          "actions": [
+            {
+              "name": "alert-create",
+              "description": "\"Create a metric or log alert with action groups for Azure Monitor\"",
+              "source": "azure-monitor/commands/alert-create.md"
+            },
+            {
+              "name": "appinsights-setup",
+              "description": "\"Add Application Insights instrumentation to a Node.js/TypeScript project with sampling configuration\"",
+              "source": "azure-monitor/commands/appinsights-setup.md"
+            },
+            {
+              "name": "dashboard-create",
+              "description": "\"Create an Azure Dashboard or Workbook from KQL queries for monitoring visualization\"",
+              "source": "azure-monitor/commands/dashboard-create.md"
+            },
+            {
+              "name": "diagnostic-settings",
+              "description": "\"Configure diagnostic settings to send Azure resource logs and metrics to Log Analytics, Storage, or Event Hubs\"",
+              "source": "azure-monitor/commands/diagnostic-settings.md"
+            },
+            {
+              "name": "kql-query",
+              "description": "\"Write and run KQL queries against Log Analytics or Application Insights, with result explanation\"",
+              "source": "azure-monitor/commands/kql-query.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Azure Monitor plugin — install Azure CLI, create a Log Analytics workspace, and enable diagnostic settings",
+              "source": "azure-monitor/commands/setup.md"
+            }
+          ],
+          "prerequisites": [
+            "**Audience** — Ops team (detailed), management (high-level KPIs), or developers (debug-focused)",
+            "**Azure CLI 2.50+**: Required for all Azure Monitor operations.",
+            "**Key metrics** — What they want to see at a glance (errors, latency, throughput, availability, resource utilization)",
+            "**Node.js 18+**: Required if instrumenting a Node.js application with Application Insights.",
+            "**Target resources** — Which Azure resources or Application Insights instances to monitor",
+            "**Time range** — Default time range for the dashboard (e.g., last 24 hours, last 7 days)"
+          ]
+        }
+      }
+    },
+    "azure-networking": {
+      "category": "cloud",
+      "description": "Azure Networking — VNets, subnets, NSGs, Load Balancers, Front Door, DNS zones, VPN gateways, and Private Link",
+      "files": {
+        "manifest": "azure-networking/.claude-plugin/plugin.json",
+        "readme": "azure-networking/README.md",
+        "skills": [
+          "azure-networking/skills/azure-networking/SKILL.md"
+        ],
+        "commands": [
+          "azure-networking/commands/dns-manage.md",
+          "azure-networking/commands/lb-create.md",
+          "azure-networking/commands/nsg-configure.md",
+          "azure-networking/commands/private-endpoint-create.md",
+          "azure-networking/commands/setup.md",
+          "azure-networking/commands/vnet-create.md"
+        ],
+        "agents": [
+          "azure-networking/agents/networking-reviewer.md"
+        ]
+      },
+      "domains": {
+        "Networking Reviewer": {
+          "actions": [
+            {
+              "name": "dns-manage",
+              "description": "\"Manage Azure DNS zones and records — public and private zones\"",
+              "source": "azure-networking/commands/dns-manage.md"
+            },
+            {
+              "name": "lb-create",
+              "description": "\"Create a Load Balancer (public or internal) with backend pool and health probes\"",
+              "source": "azure-networking/commands/lb-create.md"
+            },
+            {
+              "name": "nsg-configure",
+              "description": "\"Create and assign NSG rules, configure ASGs, and enable flow logs\"",
+              "source": "azure-networking/commands/nsg-configure.md"
+            },
+            {
+              "name": "private-endpoint-create",
+              "description": "\"Create a Private Endpoint for Azure services with DNS integration\"",
+              "source": "azure-networking/commands/private-endpoint-create.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up Azure Networking plugin — install Azure CLI, verify networking providers, check subscription quotas",
+              "source": "azure-networking/commands/setup.md"
+            },
+            {
+              "name": "vnet-create",
+              "description": "\"Create a Virtual Network with subnets, peering, and service endpoints\"",
+              "source": "azure-networking/commands/vnet-create.md"
+            }
+          ],
+          "prerequisites": [
+            "**Azure CLI 2.50+**: Required for all networking commands."
+          ]
+        }
+      }
+    },
+    "fabric-data-engineering": {
+      "category": "analytics",
+      "description": "Microsoft Fabric Data Engineering — lakehouses, Spark notebooks, data pipelines, Delta Lake tables, and lakehouse SQL endpoints",
+      "files": {
+        "manifest": "fabric-data-engineering/.claude-plugin/plugin.json",
+        "readme": "fabric-data-engineering/README.md",
+        "skills": [
+          "fabric-data-engineering/skills/fabric-data-engineering/SKILL.md"
+        ],
+        "commands": [
+          "fabric-data-engineering/commands/delta-table-manage.md",
+          "fabric-data-engineering/commands/lakehouse-create.md",
+          "fabric-data-engineering/commands/lakehouse-load-data.md",
+          "fabric-data-engineering/commands/notebook-create.md",
+          "fabric-data-engineering/commands/pipeline-create.md",
+          "fabric-data-engineering/commands/setup.md"
+        ],
+        "agents": [
+          "fabric-data-engineering/agents/data-engineering-reviewer.md"
+        ]
+      },
+      "domains": {
+        "Data Engineering Reviewer": {
+          "actions": [
+            {
+              "name": "delta-table-manage",
+              "description": "\"Create, optimize, vacuum, and manage Delta Lake tables in a Fabric lakehouse\"",
+              "source": "fabric-data-engineering/commands/delta-table-manage.md"
+            },
+            {
+              "name": "lakehouse-create",
+              "description": "\"Create a Fabric lakehouse with medallion folder structure and SQL analytics endpoint\"",
+              "source": "fabric-data-engineering/commands/lakehouse-create.md"
+            },
+            {
+              "name": "lakehouse-load-data",
+              "description": "\"Load data from files, APIs, or databases into lakehouse Delta tables\"",
+              "source": "fabric-data-engineering/commands/lakehouse-load-data.md"
+            },
+            {
+              "name": "notebook-create",
+              "description": "\"Create a Fabric Spark notebook with starter code for a given scenario\"",
+              "source": "fabric-data-engineering/commands/notebook-create.md"
+            },
+            {
+              "name": "pipeline-create",
+              "description": "\"Create a Fabric data pipeline with activities, error handling, and scheduling\"",
+              "source": "fabric-data-engineering/commands/pipeline-create.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Fabric Data Engineering plugin — verify Fabric capacity, create workspace, configure lakehouse access",
+              "source": "fabric-data-engineering/commands/setup.md"
+            }
+          ],
+          "prerequisites": [
+            "**Azure CLI**: For managing Fabric capacities and RBAC.",
+            "**Azure subscription**: Required for Fabric capacity (F SKUs) or a Fabric trial.",
+            "**Python 3.10+**: Required for local PySpark development and testing."
+          ]
+        }
+      }
+    },
+    "fabric-data-warehouse": {
+      "category": "analytics",
+      "description": "Microsoft Fabric Data Warehouse — Synapse warehouses, T-SQL DDL/DML, cross-database queries, stored procedures, and data modeling",
+      "files": {
+        "manifest": "fabric-data-warehouse/.claude-plugin/plugin.json",
+        "readme": "fabric-data-warehouse/README.md",
+        "skills": [
+          "fabric-data-warehouse/skills/fabric-data-warehouse/SKILL.md"
+        ],
+        "commands": [
+          "fabric-data-warehouse/commands/setup.md",
+          "fabric-data-warehouse/commands/warehouse-create.md",
+          "fabric-data-warehouse/commands/warehouse-load.md",
+          "fabric-data-warehouse/commands/warehouse-monitor.md",
+          "fabric-data-warehouse/commands/warehouse-query.md",
+          "fabric-data-warehouse/commands/warehouse-table-create.md"
+        ],
+        "agents": [
+          "fabric-data-warehouse/agents/warehouse-reviewer.md"
+        ]
+      },
+      "domains": {
+        "Warehouse Reviewer": {
+          "actions": [
+            {
+              "name": "setup",
+              "description": "Set up the Fabric Data Warehouse plugin — configure workspace connection, install SQL tools, verify access",
+              "source": "fabric-data-warehouse/commands/setup.md"
+            },
+            {
+              "name": "warehouse-create",
+              "description": "\"Create a new Fabric Data Warehouse with schemas and initial configuration\"",
+              "source": "fabric-data-warehouse/commands/warehouse-create.md"
+            },
+            {
+              "name": "warehouse-load",
+              "description": "\"Generate data loading scripts — COPY INTO, CTAS, MERGE, or incremental load procedures\"",
+              "source": "fabric-data-warehouse/commands/warehouse-load.md"
+            },
+            {
+              "name": "warehouse-monitor",
+              "description": "\"Generate monitoring queries for warehouse performance, long-running queries, and capacity usage\"",
+              "source": "fabric-data-warehouse/commands/warehouse-monitor.md"
+            },
+            {
+              "name": "warehouse-query",
+              "description": "\"Generate optimized T-SQL queries, views, or CTEs for the Fabric Data Warehouse\"",
+              "source": "fabric-data-warehouse/commands/warehouse-query.md"
+            },
+            {
+              "name": "warehouse-table-create",
+              "description": "\"Generate CREATE TABLE DDL for dimension, fact, or staging tables with proper data types\"",
+              "source": "fabric-data-warehouse/commands/warehouse-table-create.md"
+            }
+          ],
+          "prerequisites": [
+            "**Azure CLI**: Required for authentication and Fabric REST API access.",
+            "**SQL tools**: SSMS, Azure Data Studio, or `sqlcmd` for running T-SQL."
+          ]
+        }
+      }
+    },
+    "fabric-real-time-analytics": {
+      "category": "analytics",
+      "description": "Microsoft Fabric Real-Time Analytics — Eventhouse, KQL databases, eventstreams, Real-Time Dashboards, and streaming ingestion",
+      "files": {
+        "manifest": "fabric-real-time-analytics/.claude-plugin/plugin.json",
+        "readme": "fabric-real-time-analytics/README.md",
+        "skills": [
+          "fabric-real-time-analytics/skills/fabric-real-time-analytics/SKILL.md"
+        ],
+        "commands": [
+          "fabric-real-time-analytics/commands/data-activator-trigger.md",
+          "fabric-real-time-analytics/commands/eventhouse-create.md",
+          "fabric-real-time-analytics/commands/eventstream-create.md",
+          "fabric-real-time-analytics/commands/kql-query.md",
+          "fabric-real-time-analytics/commands/rt-dashboard-create.md",
+          "fabric-real-time-analytics/commands/setup.md"
+        ],
+        "agents": [
+          "fabric-real-time-analytics/agents/realtime-reviewer.md"
+        ]
+      },
+      "domains": {
+        "Real-Time Analytics Reviewer": {
+          "actions": [
+            {
+              "name": "data-activator-trigger",
+              "description": "\"Create a Data Activator (Reflex) trigger — monitor data for conditions and fire automated actions\"",
+              "source": "fabric-real-time-analytics/commands/data-activator-trigger.md"
+            },
+            {
+              "name": "eventhouse-create",
+              "description": "\"Create an Eventhouse with KQL database, table schema, ingestion mappings, and policies\"",
+              "source": "fabric-real-time-analytics/commands/eventhouse-create.md"
+            },
+            {
+              "name": "eventstream-create",
+              "description": "\"Design an Eventstream pipeline — configure sources, transformations, and destinations for streaming ingestion\"",
+              "source": "fabric-real-time-analytics/commands/eventstream-create.md"
+            },
+            {
+              "name": "kql-query",
+              "description": "\"Generate and run KQL queries — explore data, aggregate metrics, detect anomalies, build time series\"",
+              "source": "fabric-real-time-analytics/commands/kql-query.md"
+            },
+            {
+              "name": "rt-dashboard-create",
+              "description": "\"Create a Real-Time Dashboard with KQL-powered tiles, parameters, and auto-refresh\"",
+              "source": "fabric-real-time-analytics/commands/rt-dashboard-create.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Fabric Real-Time Analytics plugin — install SDKs, configure workspace access, verify Eventhouse connectivity",
+              "source": "fabric-real-time-analytics/commands/setup.md"
+            }
+          ],
+          "prerequisites": [
+            "**Azure CLI**: Required for authentication and Fabric REST API calls.",
+            "**Node.js 18+**: Required for Kusto SDK and Eventstream custom app ingestion.",
+            "**npm**: Comes with Node.js."
+          ]
+        }
+      }
+    },
+    "fabric-data-factory": {
+      "category": "analytics",
+      "description": "Microsoft Fabric Data Factory — data pipelines, Dataflow Gen2, Copy activity, orchestration patterns, and scheduling",
+      "files": {
+        "manifest": "fabric-data-factory/.claude-plugin/plugin.json",
+        "readme": "fabric-data-factory/README.md",
+        "skills": [
+          "fabric-data-factory/skills/fabric-data-factory/SKILL.md"
+        ],
+        "commands": [
+          "fabric-data-factory/commands/copy-activity-config.md",
+          "fabric-data-factory/commands/dataflow-create.md",
+          "fabric-data-factory/commands/pipeline-create.md",
+          "fabric-data-factory/commands/pipeline-monitor.md",
+          "fabric-data-factory/commands/pipeline-schedule.md",
+          "fabric-data-factory/commands/setup.md"
+        ],
+        "agents": [
+          "fabric-data-factory/agents/data-factory-reviewer.md"
+        ]
+      },
+      "domains": {
+        "Data Factory Reviewer": {
+          "actions": [
+            {
+              "name": "copy-activity-config",
+              "description": "\"Configure a Copy activity with source, sink, column mapping, and performance settings\"",
+              "source": "fabric-data-factory/commands/copy-activity-config.md"
+            },
+            {
+              "name": "dataflow-create",
+              "description": "\"Create a Dataflow Gen2 with Power Query M transformations and lakehouse staging\"",
+              "source": "fabric-data-factory/commands/dataflow-create.md"
+            },
+            {
+              "name": "pipeline-create",
+              "description": "\"Create a new Fabric Data Factory pipeline with activities, parameters, and dependencies\"",
+              "source": "fabric-data-factory/commands/pipeline-create.md"
+            },
+            {
+              "name": "pipeline-monitor",
+              "description": "\"Monitor pipeline and activity run status, duration, and errors in Fabric Data Factory\"",
+              "source": "fabric-data-factory/commands/pipeline-monitor.md"
+            },
+            {
+              "name": "pipeline-schedule",
+              "description": "\"Create or update a schedule trigger for a Fabric Data Factory pipeline\"",
+              "source": "fabric-data-factory/commands/pipeline-schedule.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Fabric Data Factory plugin — configure workspace access, authenticate with Azure, and verify Fabric API connectivity",
+              "source": "fabric-data-factory/commands/setup.md"
+            }
+          ],
+          "prerequisites": [
+            "**Add columns**: Computed columns, conditional columns, index columns",
+            "**Append queries**: Union multiple tables",
+            "**Azure CLI**: Required for authentication and Fabric REST API access.",
+            "**Change types**: Set correct data types",
+            "**Custom M**: Any custom Power Query M expressions",
+            "**Filter rows**: Remove nulls, filter by condition",
+            "**Group by**: Aggregate rows (sum, count, average, min, max)",
+            "**Merge queries**: Join with another table (inner, left outer, full outer)",
+            "**Node.js 18+**: Required for tooling and scripting.",
+            "**Pivot/unpivot**: Reshape data",
+            "**Power Query SDK** (optional): For local Dataflow Gen2 M query development.",
+            "**Rename columns**: Clean up column names",
+            "**Select/remove columns**: Keep only needed columns"
+          ]
+        }
+      }
+    },
+    "fabric-data-science": {
+      "category": "analytics",
+      "description": "Microsoft Fabric Data Science — ML experiments, model training, MLflow tracking, PREDICT function, and semantic link integration",
+      "files": {
+        "manifest": "fabric-data-science/.claude-plugin/plugin.json",
+        "readme": "fabric-data-science/README.md",
+        "skills": [
+          "fabric-data-science/skills/fabric-data-science/SKILL.md"
+        ],
+        "commands": [
+          "fabric-data-science/commands/experiment-create.md",
+          "fabric-data-science/commands/model-predict.md",
+          "fabric-data-science/commands/model-register.md",
+          "fabric-data-science/commands/model-train.md",
+          "fabric-data-science/commands/semantic-link-query.md",
+          "fabric-data-science/commands/setup.md"
+        ],
+        "agents": [
+          "fabric-data-science/agents/data-science-reviewer.md"
+        ]
+      },
+      "domains": {
+        "Data Science Reviewer": {
+          "actions": [
+            {
+              "name": "experiment-create",
+              "description": "\"Create a new MLflow experiment in Fabric with tracking configuration and initial notebook scaffold\"",
+              "source": "fabric-data-science/commands/experiment-create.md"
+            },
+            {
+              "name": "model-predict",
+              "description": "\"Generate batch scoring code using PREDICT function or MLflow model loading\"",
+              "source": "fabric-data-science/commands/model-predict.md"
+            },
+            {
+              "name": "model-register",
+              "description": "\"Register a trained model from an MLflow experiment to the Fabric model registry\"",
+              "source": "fabric-data-science/commands/model-register.md"
+            },
+            {
+              "name": "model-train",
+              "description": "\"Generate a model training notebook with MLflow tracking, evaluation, and comparison\"",
+              "source": "fabric-data-science/commands/model-train.md"
+            },
+            {
+              "name": "semantic-link-query",
+              "description": "\"Query Power BI datasets from a Fabric notebook using semantic link (SemPy)\"",
+              "source": "fabric-data-science/commands/semantic-link-query.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Fabric Data Science plugin — configure workspace, lakehouse connection, and install Python ML libraries",
+              "source": "fabric-data-science/commands/setup.md"
+            }
+          ],
+          "prerequisites": [
+            "**Azure CLI** (optional): For programmatic workspace management.",
+            "**Microsoft Fabric capacity**: The user needs access to a Fabric workspace with a capacity (F2+ or Trial).",
+            "**Python 3.10+**: Fabric notebooks run Python 3.10 by default."
+          ]
+        }
+      }
+    },
+    "fabric-data-activator": {
+      "category": "analytics",
+      "description": "Microsoft Fabric Data Activator — Reflex triggers, condition-based alerts, real-time actions, and event-driven automation on Fabric data",
+      "files": {
+        "manifest": "fabric-data-activator/.claude-plugin/plugin.json",
+        "readme": "fabric-data-activator/README.md",
+        "skills": [
+          "fabric-data-activator/skills/fabric-data-activator/SKILL.md"
+        ],
+        "commands": [
+          "fabric-data-activator/commands/action-configure.md",
+          "fabric-data-activator/commands/reflex-create.md",
+          "fabric-data-activator/commands/reflex-from-report.md",
+          "fabric-data-activator/commands/reflex-monitor.md",
+          "fabric-data-activator/commands/setup.md",
+          "fabric-data-activator/commands/trigger-define.md"
+        ],
+        "agents": [
+          "fabric-data-activator/agents/activator-reviewer.md"
+        ]
+      },
+      "domains": {
+        "Activator Reviewer": {
+          "actions": [
+            {
+              "name": "action-configure",
+              "description": "\"Configure an action (email, Teams, Power Automate, webhook) on a Data Activator trigger\"",
+              "source": "fabric-data-activator/commands/action-configure.md"
+            },
+            {
+              "name": "reflex-create",
+              "description": "\"Create a new Reflex item in a Fabric workspace with objects and data source binding\"",
+              "source": "fabric-data-activator/commands/reflex-create.md"
+            },
+            {
+              "name": "reflex-from-report",
+              "description": "\"Create a Reflex trigger directly from a Power BI report visual — guided no-code alert setup\"",
+              "source": "fabric-data-activator/commands/reflex-from-report.md"
+            },
+            {
+              "name": "reflex-monitor",
+              "description": "\"Monitor Reflex trigger health — view trigger history, action execution logs, and diagnose issues\"",
+              "source": "fabric-data-activator/commands/reflex-monitor.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Fabric Data Activator plugin — verify Fabric workspace access, configure Azure identity, and prepare eventstream connectivity",
+              "source": "fabric-data-activator/commands/setup.md"
+            },
+            {
+              "name": "trigger-define",
+              "description": "\"Define a trigger condition on a Reflex object property with threshold, state change, or absence detection\"",
+              "source": "fabric-data-activator/commands/trigger-define.md"
+            }
+          ],
+          "prerequisites": [
+            "**Azure CLI**: Required for authentication and API access.",
+            "**Fabric workspace**: The user must have access to a Fabric-enabled workspace with at least Contributor role."
+          ]
+        }
+      }
+    },
+    "fabric-onelake": {
+      "category": "analytics",
+      "description": "Microsoft Fabric OneLake — unified data lake, shortcuts, file explorer, ADLS Gen2 APIs, and cross-workspace data access",
+      "files": {
+        "manifest": "fabric-onelake/.claude-plugin/plugin.json",
+        "readme": "fabric-onelake/README.md",
+        "skills": [
+          "fabric-onelake/skills/fabric-onelake/SKILL.md"
+        ],
+        "commands": [
+          "fabric-onelake/commands/onelake-access-audit.md",
+          "fabric-onelake/commands/onelake-browse.md",
+          "fabric-onelake/commands/onelake-file-api.md",
+          "fabric-onelake/commands/onelake-upload.md",
+          "fabric-onelake/commands/setup.md",
+          "fabric-onelake/commands/shortcut-create.md"
+        ],
+        "agents": [
+          "fabric-onelake/agents/onelake-reviewer.md"
+        ]
+      },
+      "domains": {
+        "OneLake Reviewer": {
+          "actions": [
+            {
+              "name": "onelake-access-audit",
+              "description": "\"Audit OneLake access roles, item permissions, sharing links, and workspace identity configuration\"",
+              "source": "fabric-onelake/commands/onelake-access-audit.md"
+            },
+            {
+              "name": "onelake-browse",
+              "description": "\"Browse OneLake hierarchy — list workspaces, items, folders, and files via DFS API\"",
+              "source": "fabric-onelake/commands/onelake-browse.md"
+            },
+            {
+              "name": "onelake-file-api",
+              "description": "\"Generate OneLake REST API or SDK code for file and directory operations\"",
+              "source": "fabric-onelake/commands/onelake-file-api.md"
+            },
+            {
+              "name": "onelake-upload",
+              "description": "\"Upload local files or directories to a OneLake lakehouse via DFS API\"",
+              "source": "fabric-onelake/commands/onelake-upload.md"
+            },
+            {
+              "name": "setup",
+              "description": "Set up the Fabric OneLake plugin — install Azure CLI, authenticate, configure workspace access and OneLake endpoints",
+              "source": "fabric-onelake/commands/setup.md"
+            },
+            {
+              "name": "shortcut-create",
+              "description": "\"Create a OneLake shortcut to ADLS Gen2, Amazon S3, Google Cloud Storage, Dataverse, or another OneLake item\"",
+              "source": "fabric-onelake/commands/shortcut-create.md"
+            }
+          ],
+          "prerequisites": [
+            "**Node.js 18+**: Required for Azure SDK packages.",
+            "**Python 3.10+** (optional): Required for `azure-storage-file-datalake` Python SDK.",
+            "**npm**: Comes with Node.js.",
+            "Inconsistent permissions between related items (e.g., gold lakehouse more open than silver)",
+            "Items shared externally (B2B guests) without business justification",
+            "Items shared with `ReadAll` permission to broad audiences (grants access to all data)",
+            "Python: `DefaultAzureCredential` from `azure.identity`",
+            "TypeScript: `DefaultAzureCredential` from `@azure/identity`",
+            "curl: `az account get-access-token` for bearer token"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,11 +13,12 @@
     "test:coverage": "jest --coverage",
     "lint": "tsc --noEmit",
     "validate:marketplace": "node scripts/validate-marketplace.mjs",
-    "validate:all": "npm run validate:marketplace && npm run validate:knowledge-plugins && npm run validate:command-frontmatter",
+    "validate:all": "npm run validate:marketplace && npm run validate:knowledge-plugins && npm run validate:command-frontmatter && npm run validate:capability-graph",
     "validate:plugins": "node scripts/validate-plugins.mjs",
     "validate:command-frontmatter": "node scripts/validate-command-frontmatter.mjs",
     "validate:knowledge-plugins": "node scripts/validate-plugins.mjs",
-    "research": "node marketplace-dev-tools/scripts/research-service.mjs"
+    "research": "node marketplace-dev-tools/scripts/research-service.mjs",
+    "validate:capability-graph": "node scripts/validate-capability-graph.mjs"
   },
   "repository": {
     "type": "git",

--- a/scripts/validate-capability-graph.mjs
+++ b/scripts/validate-capability-graph.mjs
@@ -1,0 +1,275 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+
+const rootDir = process.cwd();
+const artifactsDir = path.join(rootDir, 'artifacts');
+const outputPath = path.join(artifactsDir, 'capability-graph.json');
+const marketplacePath = path.join(rootDir, '.claude-plugin', 'marketplace.json');
+const claudeCatalogPath = path.join(rootDir, 'CLAUDE.md');
+
+const marketplace = JSON.parse(fs.readFileSync(marketplacePath, 'utf8'));
+const claudeCatalog = parseClaudeCatalog(fs.readFileSync(claudeCatalogPath, 'utf8'));
+const strictPlugins = detectChangedPlugins();
+
+let hasError = false;
+const graph = {
+  strictPluginScope: Array.from(strictPlugins).sort(),
+  sourceFiles: {
+    claudeCatalog: toRepoPath(claudeCatalogPath),
+    marketplace: toRepoPath(marketplacePath)
+  },
+  plugins: {}
+};
+
+for (const pluginEntry of marketplace.plugins ?? []) {
+  if (typeof pluginEntry.source !== 'string' || !pluginEntry.source.startsWith('./')) continue;
+
+  const pluginDir = path.join(rootDir, pluginEntry.source.slice(2));
+  const manifestPath = path.join(pluginDir, '.claude-plugin', 'plugin.json');
+  const readmePath = path.join(pluginDir, 'README.md');
+  const skillsDir = path.join(pluginDir, 'skills');
+  const commandsDir = path.join(pluginDir, 'commands');
+  const agentsDir = path.join(pluginDir, 'agents');
+
+  if (!assertFileExists(manifestPath, pluginEntry.name, 'manifest')) continue;
+  if (!assertFileExists(readmePath, pluginEntry.name, 'README')) continue;
+
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  const readme = fs.readFileSync(readmePath, 'utf8');
+  const skillFiles = getSkillFiles(skillsDir);
+  const commandFiles = getMarkdownFiles(commandsDir);
+  const agentFiles = getMarkdownFiles(agentsDir);
+  const catalogEntry = claudeCatalog.get(pluginEntry.name);
+
+  graph.plugins[pluginEntry.name] = {
+    category: pluginEntry.category,
+    description: pluginEntry.description,
+    files: {
+      manifest: toRepoPath(manifestPath),
+      readme: toRepoPath(readmePath),
+      skills: skillFiles.map(toRepoPath),
+      commands: commandFiles.map(toRepoPath),
+      agents: agentFiles.map(toRepoPath)
+    },
+    domains: buildDomains(pluginEntry, readme, readmePath, skillFiles, commandFiles)
+  };
+
+  const isStrict = strictPlugins.has(pluginEntry.name);
+  validateDrift({ pluginEntry, manifest, catalogEntry, pluginDir, manifestPath, readme, readmePath, isStrict });
+  validateIntegrationMetadata({ pluginEntry, readme, readmePath, skillFiles, commandFiles, agentFiles, isStrict });
+}
+
+fs.mkdirSync(artifactsDir, { recursive: true });
+fs.writeFileSync(outputPath, `${JSON.stringify(graph, null, 2)}\n`, 'utf8');
+console.log(`Wrote capability graph: ${toRepoPath(outputPath)}`);
+
+if (hasError) process.exit(1);
+console.log('Capability graph validation passed.');
+
+function buildDomains(pluginEntry, readme, readmePath, skillFiles, commandFiles) {
+  const domainSet = new Set(extractReadmeDomains(readme));
+  if (domainSet.size === 0) domainSet.add(pluginEntry.category || 'general');
+  const prerequisites = collectPrerequisites([readmePath, ...skillFiles, ...commandFiles]);
+  const actions = commandFiles.map((commandPath) => extractAction(commandPath));
+
+  const domains = {};
+  for (const domain of domainSet) domains[domain] = { actions, prerequisites };
+  return domains;
+}
+
+function validateDrift({ pluginEntry, manifest, catalogEntry, pluginDir, manifestPath, readme, readmePath, isStrict }) {
+  const folderSlug = path.basename(pluginDir);
+  if (folderSlug !== pluginEntry.name) {
+    fail(`Slug mismatch: marketplace "${pluginEntry.name}" != folder "${folderSlug}". Fix ${toRepoPath(pluginDir)} or ${toRepoPath(marketplacePath)}.`);
+  }
+  if (manifest.name !== pluginEntry.name) {
+    fail(`Name drift: ${toRepoPath(manifestPath)} has name "${manifest.name}" but marketplace expects "${pluginEntry.name}".`);
+  }
+  if (!catalogEntry) {
+    fail(`Missing CLAUDE catalog entry for "${pluginEntry.name}". Fix ${toRepoPath(claudeCatalogPath)} table.`);
+    return;
+  }
+  if (catalogEntry.category !== pluginEntry.category) {
+    fail(`Category drift for "${pluginEntry.name}": CLAUDE.md="${catalogEntry.category}" vs marketplace="${pluginEntry.category}". Fix ${toRepoPath(claudeCatalogPath)} or ${toRepoPath(marketplacePath)}.`);
+  }
+
+  if (isStrict && !isDescriptionAligned(catalogEntry.description, pluginEntry.description)) {
+    fail(`Description drift for "${pluginEntry.name}": CLAUDE.md and marketplace descriptions differ. Fix ${toRepoPath(claudeCatalogPath)} or ${toRepoPath(marketplacePath)}.`);
+  }
+  if (isStrict && !new RegExp(`\\b${escapeRegExp(pluginEntry.name)}\\b`, 'i').test(readme)) {
+    fail(`README naming drift for "${pluginEntry.name}": slug is not referenced in ${toRepoPath(readmePath)}.`);
+  }
+}
+
+function validateIntegrationMetadata({ pluginEntry, readme, readmePath, skillFiles, commandFiles, agentFiles, isStrict }) {
+  if (skillFiles.length === 0) {
+    fail(`Missing skill docs for "${pluginEntry.name}". Add skills/*/SKILL.md in ${toRepoPath(path.join(rootDir, pluginEntry.source.slice(2)))}.`);
+  }
+  if (commandFiles.length === 0) {
+    fail(`Missing command docs for "${pluginEntry.name}". Add commands/*.md in ${toRepoPath(path.join(rootDir, pluginEntry.source.slice(2)))}.`);
+  }
+  if (!isStrict) return;
+
+  const prereqSources = [
+    hasPrereqSection(readme) ? toRepoPath(readmePath) : null,
+    ...skillFiles.filter((p) => hasPrereqSection(fs.readFileSync(p, 'utf8'))).map(toRepoPath),
+    ...commandFiles.filter((p) => hasPrereqSection(fs.readFileSync(p, 'utf8'))).map(toRepoPath)
+  ].filter(Boolean);
+  if (prereqSources.length === 0) {
+    fail(`Missing prerequisites metadata for "${pluginEntry.name}". Add a "Prerequisites"/"Requirements" section in ${toRepoPath(readmePath)} or related skill/command docs.`);
+  }
+
+  for (const skillPath of skillFiles) {
+    if (!hasTriggers(fs.readFileSync(skillPath, 'utf8'))) {
+      fail(`Missing trigger phrases in ${toRepoPath(skillPath)}. Add non-empty frontmatter "triggers" entries.`);
+    }
+  }
+  for (const agentPath of agentFiles) {
+    if (!hasOutputFormat(fs.readFileSync(agentPath, 'utf8'))) {
+      fail(`Missing output format metadata in ${toRepoPath(agentPath)}. Add an explicit output/report format section and checklist-style review criteria.`);
+    }
+  }
+}
+
+function detectChangedPlugins() {
+  const files = runGitDiffFiles();
+  const changed = new Set();
+  for (const file of files) {
+    const root = file.split('/')[0];
+    if (marketplace.plugins.some((p) => typeof p.source === 'string' && p.source === `./${root}`)) {
+      changed.add(root);
+    }
+  }
+  return changed;
+}
+
+function runGitDiffFiles() {
+  const candidates = [
+    'git diff --name-only --diff-filter=ACMR $(git merge-base HEAD origin/main)',
+    'git diff --name-only --diff-filter=ACMR HEAD~1'
+  ];
+
+  for (const cmd of candidates) {
+    try {
+      const out = execSync(cmd, { cwd: rootDir, stdio: ['ignore', 'pipe', 'ignore'], shell: '/bin/bash' }).toString('utf8');
+      return out.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+    } catch {
+      // try next strategy
+    }
+  }
+  return [];
+}
+
+function parseClaudeCatalog(content) {
+  const catalog = new Map();
+  for (const line of content.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('| `') || !trimmed.endsWith('|')) continue;
+    const cells = trimmed.slice(1, -1).split('|').map((c) => c.trim());
+    const slugMatch = cells[0]?.match(/^`([^`]+)`$/);
+    if (!slugMatch || cells.length < 3) continue;
+    catalog.set(slugMatch[1], { category: cells[1], description: cells[2] });
+  }
+  return catalog;
+}
+
+function getSkillFiles(skillsDir) {
+  if (!fs.existsSync(skillsDir) || !fs.statSync(skillsDir).isDirectory()) return [];
+  return fs.readdirSync(skillsDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(skillsDir, entry.name, 'SKILL.md'))
+    .filter((skillPath) => fs.existsSync(skillPath));
+}
+
+function getMarkdownFiles(directory) {
+  if (!fs.existsSync(directory) || !fs.statSync(directory).isDirectory()) return [];
+  return fs.readdirSync(directory, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))
+    .map((entry) => path.join(directory, entry.name))
+    .sort();
+}
+
+function hasTriggers(content) {
+  const frontmatter = content.match(/^---\n([\s\S]*?)\n---\n?/);
+  if (!frontmatter) return false;
+  const triggerBlock = frontmatter[1].match(/(^|\n)triggers:\s*\n([\s\S]*?)(\n[a-zA-Z-]+:\s|$)/);
+  return Boolean(triggerBlock && /\n\s*-\s*\S+/.test(`\n${triggerBlock[2]}`));
+}
+
+function hasOutputFormat(content) {
+  const hasFormatSection = /(##|###)\s*(output format|review output|report format|response format)\b/i.test(content);
+  const hasStructuredTemplate = /```[\s\S]*?(review summary|issues found|overall)\b/i.test(content);
+  const hasActionableChecks = /(##|###)\s*(checks|review checklist|validation checklist)\b/i.test(content) || /^[-*]\s+Verify\b/m.test(content);
+  return (hasFormatSection || hasStructuredTemplate) && hasActionableChecks;
+}
+
+function hasPrereqSection(content) {
+  return /^(##|###)\s+.*(prerequisites?|requirements?|permissions?|authentication)\b/im.test(content);
+}
+
+function extractReadmeDomains(content) {
+  return (content.match(/^\|\s*\*\*.+$/gm) ?? [])
+    .map((row) => row.split('|').map((c) => c.trim()).filter(Boolean))
+    .filter((cells) => cells.length >= 2)
+    .map((cells) => cells[0].replace(/^\*\*|\*\*$/g, '').trim());
+}
+
+function collectPrerequisites(filePaths) {
+  const prereqs = new Set();
+  for (const filePath of filePaths) {
+    const lines = fs.readFileSync(filePath, 'utf8').split(/\r?\n/);
+    let capture = false;
+    for (const line of lines) {
+      if (/^(##|###)\s+.*(prerequisites?|requirements?|permissions?|authentication)\b/i.test(line)) {
+        capture = true;
+        continue;
+      }
+      if (capture && /^(##|###)\s+/.test(line)) capture = false;
+      if (!capture) continue;
+      const bullet = line.match(/^[-*]\s+(.+)/)?.[1]?.trim();
+      if (bullet) prereqs.add(bullet);
+    }
+  }
+  return Array.from(prereqs).sort();
+}
+
+function extractAction(commandPath) {
+  const content = fs.readFileSync(commandPath, 'utf8');
+  const frontmatter = content.match(/^---\n([\s\S]*?)\n---\n?/);
+  const h1 = content.match(/^#\s+(.+)$/m)?.[1]?.trim();
+  return {
+    name: frontmatter?.[1].match(/(^|\n)name:\s*(.+)$/m)?.[2]?.trim() || path.basename(commandPath, '.md'),
+    description: frontmatter?.[1].match(/(^|\n)description:\s*(.+)$/m)?.[2]?.trim() || h1 || '',
+    source: toRepoPath(commandPath)
+  };
+}
+
+function isDescriptionAligned(left, right) {
+  const l = normalize(left);
+  const r = normalize(right);
+  return l === r || l.includes(r) || r.includes(l);
+}
+
+function normalize(value) {
+  return String(value ?? '').toLowerCase().replace(/[—–]/g, '-').replace(/[^a-z0-9]+/g, ' ').trim();
+}
+
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function assertFileExists(filePath, pluginName, label) {
+  if (fs.existsSync(filePath)) return true;
+  fail(`Missing ${label} for "${pluginName}": ${toRepoPath(filePath)}.`);
+  return false;
+}
+
+function toRepoPath(absolutePath) {
+  return path.relative(rootDir, absolutePath) || '.';
+}
+
+function fail(message) {
+  hasError = true;
+  console.error(message);
+}


### PR DESCRIPTION
### Motivation
- Provide a machine-readable capability index to enable plugin → domain → action → prerequisite routing and surface integration regressions early in CI.
- Detect cross-file drift and missing integration metadata (name/slug/category/description, triggers, prereqs, output format) so PRs fail with actionable file-level errors.
- Limit strict checks to changed plugins to avoid blocking unrelated work while still failing regressions early.

### Description
- Add `scripts/validate-capability-graph.mjs` which parses `CLAUDE.md`, `.claude-plugin/marketplace.json`, each plugin `.claude-plugin/plugin.json`, `README.md`, `skills/*/SKILL.md`, `commands/*.md`, and `agents/*.md` and writes `artifacts/capability-graph.json` that maps plugin → domains → actions → prerequisites.
- Emit path-specific, actionable validation errors for slug/name/category/description drift and for missing integration metadata such as prerequisites, trigger phrases, and reviewer output-format/checklist requirements.
- Compute a `strictPluginScope` from git diffs and apply stricter checks (description alignment, README slug reference, prereq/trigger/output-format presence) only to changed plugins to minimize noise.
- Wire validation into CI by adding a `validate:capability-graph` npm script and appending it to `validate:all`, and include the generated `artifacts/capability-graph.json` snapshot.

### Testing
- Ran `node --check scripts/validate-capability-graph.mjs` which passed with no syntax errors.
- Ran `node scripts/validate-capability-graph.mjs` which wrote `artifacts/capability-graph.json` and exited successfully.
- Ran `npm run validate:marketplace && node scripts/validate-capability-graph.mjs` which succeeded.
- Ran `npm run validate:all` which failed due to pre-existing repository issues reported by `validate:knowledge-plugins`, not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a52cbe68ac832a9a69f0e23b4d9406)