### PR TITLE
Fix plugin marketplace displaying only 5 plugins instead of all 94

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -140,7 +140,9 @@ export async function createServer(): Promise<McpServer> {
           p.name.toLowerCase().includes(keyword) ||
           p.description.toLowerCase().includes(keyword) ||
           p.id.toLowerCase().includes(keyword) ||
-          p.tools.some((t) => t.toLowerCase().includes(keyword))
+          (p.tools ?? []).some((t) => t.toLowerCase().includes(keyword)) ||
+          (p.tags ?? []).some((t) => t.toLowerCase().includes(keyword)) ||
+          (p.category ?? "").toLowerCase().includes(keyword)
       );
 
       if (matches.length === 0) {
@@ -148,7 +150,7 @@ export async function createServer(): Promise<McpServer> {
           content: [
             {
               type: "text",
-              text: `No plugins found matching '${args.keyword}'. Try searching for: teams, excel, outlook, azure, sharepoint, email, calendar, files, or resources.`,
+              text: `No plugins found matching '${args.keyword}'. Try searching for: teams, excel, outlook, azure, sharepoint, fabric, security, analytics, devops, cloud, or productivity.`,
             },
           ],
         };
@@ -166,7 +168,8 @@ export async function createServer(): Promise<McpServer> {
                   id: p.id,
                   name: p.name,
                   description: p.description,
-                  toolCount: p.tools.length,
+                  category: p.category,
+                  toolCount: (p.tools ?? []).length,
                 })),
               },
               null,
@@ -204,7 +207,7 @@ export async function createServer(): Promise<McpServer> {
       }
 
       const toolsList = plugins.flatMap((p) =>
-        p.tools.map((toolName) => ({
+        (p.tools ?? []).map((toolName) => ({
           tool: toolName,
           plugin: p.id,
           pluginName: p.name,

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,6 +1,6 @@
-import { readFileSync, readdirSync } from "fs";
+import { readFileSync, readdirSync, existsSync } from "fs";
 import { join } from "path";
-import { PluginManifest } from "./types.js";
+import { PluginManifest, MarketplaceDefinition } from "./types.js";
 
 /**
  * Resolve the registry directory relative to this file at runtime.
@@ -22,18 +22,78 @@ function registryDir(): string {
   }
 }
 
+/**
+ * Resolve the project root (one level above the registry directory).
+ */
+function projectRoot(): string {
+  return join(registryDir(), "..");
+}
+
 const REGISTRY_DIR = registryDir();
 
 /**
- * Load every JSON manifest from the registry directory and return
- * them as an array of {@link PluginManifest} objects.
+ * Load plugin manifests from individual JSON files in the registry directory.
  */
-export function loadRegistry(): PluginManifest[] {
+function loadRegistryFiles(): PluginManifest[] {
+  if (!existsSync(REGISTRY_DIR)) return [];
   const files = readdirSync(REGISTRY_DIR).filter((f) => f.endsWith(".json"));
   return files.map((file) => {
     const raw = readFileSync(join(REGISTRY_DIR, file), "utf-8");
     return JSON.parse(raw) as PluginManifest;
   });
+}
+
+/**
+ * Load plugin entries from .claude-plugin/marketplace.json and convert them
+ * to PluginManifest objects so they appear alongside registry plugins.
+ */
+function loadMarketplacePlugins(): PluginManifest[] {
+  const marketplacePath = join(projectRoot(), ".claude-plugin", "marketplace.json");
+  if (!existsSync(marketplacePath)) return [];
+
+  const raw = readFileSync(marketplacePath, "utf-8");
+  const marketplace: MarketplaceDefinition = JSON.parse(raw);
+
+  return marketplace.plugins.map((entry) => ({
+    id: entry.name,
+    name: entry.name,
+    description: entry.description,
+    version: "1.0.0",
+    category: entry.category,
+    tags: entry.tags,
+  }));
+}
+
+/**
+ * Load every plugin from both the registry directory and the marketplace
+ * definition, deduplicate by id, and return them as an array of
+ * {@link PluginManifest} objects.
+ *
+ * Registry files take precedence over marketplace entries when both define
+ * the same plugin (by id/name), since registry files carry richer metadata.
+ */
+export function loadRegistry(): PluginManifest[] {
+  const registryPlugins = loadRegistryFiles();
+  const marketplacePlugins = loadMarketplacePlugins();
+
+  // Index registry plugins by id for fast lookup
+  const seen = new Set<string>(registryPlugins.map((p) => p.id));
+
+  // Also match marketplace names to registry ids (e.g. "microsoft-teams-mcp" → "teams")
+  const registryNameSet = new Set<string>(registryPlugins.map((p) => p.name.toLowerCase()));
+  const registryDescSet = new Set<string>(registryPlugins.map((p) => p.description));
+
+  // Merge: registry first, then marketplace entries not already present
+  const merged = [...registryPlugins];
+  for (const mp of marketplacePlugins) {
+    // Skip if already in registry by id
+    if (seen.has(mp.id)) continue;
+    // Skip if the description is an exact duplicate (catches renamed variants)
+    if (registryDescSet.has(mp.description)) continue;
+    merged.push(mp);
+  }
+
+  return merged;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,14 @@ export type MicrosoftProduct =
   | "azure"
   | "sharepoint";
 
+/** Plugin category used in the marketplace definition. */
+export type PluginCategory =
+  | "productivity"
+  | "cloud"
+  | "analytics"
+  | "devops"
+  | "security";
+
 /** Authentication configuration for a plugin. */
 export interface PluginAuth {
   /** OAuth 2.0 client ID (Microsoft Entra / Azure AD app registration). */
@@ -33,13 +41,35 @@ export interface PluginManifest {
   /** Semver version string. */
   version: string;
   /** Microsoft product this plugin targets. */
-  product: MicrosoftProduct;
+  product?: MicrosoftProduct;
+  /** Plugin category from the marketplace definition. */
+  category?: PluginCategory;
+  /** Discovery tags. */
+  tags?: string[];
   /** Microsoft Graph / REST API scopes required by the plugin. */
-  requiredScopes: string[];
+  requiredScopes?: string[];
   /** Names of the MCP tools exposed by the plugin. */
-  tools: string[];
+  tools?: string[];
   /** Plugin author. */
-  author: string;
+  author?: string;
+}
+
+/** Shape of a plugin entry inside .claude-plugin/marketplace.json. */
+export interface MarketplacePluginEntry {
+  name: string;
+  source: string | { source: string; repo: string };
+  description: string;
+  category: PluginCategory;
+  tags: string[];
+  strict?: boolean;
+}
+
+/** Top-level shape of .claude-plugin/marketplace.json. */
+export interface MarketplaceDefinition {
+  name: string;
+  description: string;
+  owner?: { name: string };
+  plugins: MarketplacePluginEntry[];
 }
 
 /** Result returned by every plugin tool invocation. */

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -1,27 +1,56 @@
 import { loadRegistry, findPlugin } from "../src/registry.js";
 
 describe("Registry", () => {
-  test("loadRegistry returns all 5 manifests", () => {
+  test("loadRegistry returns plugins from both registry and marketplace", () => {
     const plugins = loadRegistry();
-    expect(plugins).toHaveLength(5);
+    // Must include at least the 5 core registry plugins
+    expect(plugins.length).toBeGreaterThanOrEqual(5);
+    // Must also include marketplace plugins (94 total in marketplace.json,
+    // minus duplicates that overlap with the 5 registry plugins)
+    expect(plugins.length).toBeGreaterThan(5);
   });
 
-  test("each manifest has the required fields", () => {
+  test("core registry manifests have rich metadata (tools, scopes)", () => {
+    const coreIds = ["teams", "excel", "outlook", "azure", "sharepoint"];
+    const plugins = loadRegistry();
+    for (const id of coreIds) {
+      const plugin = plugins.find((p) => p.id === id);
+      expect(plugin).toBeDefined();
+      expect(typeof plugin!.name).toBe("string");
+      expect(typeof plugin!.description).toBe("string");
+      expect(typeof plugin!.version).toBe("string");
+      expect(Array.isArray(plugin!.tools)).toBe(true);
+      expect(plugin!.tools!.length).toBeGreaterThan(0);
+      expect(Array.isArray(plugin!.requiredScopes)).toBe(true);
+    }
+  });
+
+  test("marketplace plugins have required base fields", () => {
     const plugins = loadRegistry();
     for (const plugin of plugins) {
       expect(typeof plugin.id).toBe("string");
       expect(typeof plugin.name).toBe("string");
       expect(typeof plugin.description).toBe("string");
       expect(typeof plugin.version).toBe("string");
-      expect(Array.isArray(plugin.tools)).toBe(true);
-      expect(plugin.tools.length).toBeGreaterThan(0);
-      expect(Array.isArray(plugin.requiredScopes)).toBe(true);
     }
   });
 
-  test("manifest IDs match expected products", () => {
-    const ids = loadRegistry().map((p) => p.id).sort();
-    expect(ids).toEqual(["azure", "excel", "outlook", "sharepoint", "teams"]);
+  test("core registry IDs are present in the combined list", () => {
+    const ids = loadRegistry().map((p) => p.id);
+    expect(ids).toContain("azure");
+    expect(ids).toContain("excel");
+    expect(ids).toContain("outlook");
+    expect(ids).toContain("sharepoint");
+    expect(ids).toContain("teams");
+  });
+
+  test("marketplace-only plugins are also present", () => {
+    const ids = loadRegistry().map((p) => p.id);
+    // Spot-check a few marketplace-only plugins
+    expect(ids).toContain("excel-office-scripts");
+    expect(ids).toContain("azure-cost-governance");
+    expect(ids).toContain("entra-id-security");
+    expect(ids).toContain("powerbi-fabric");
   });
 
   test("findPlugin returns the correct manifest", () => {
@@ -31,7 +60,20 @@ describe("Registry", () => {
     expect(manifest?.id).toBe("teams");
   });
 
+  test("findPlugin finds marketplace-only plugins", () => {
+    const manifest = findPlugin("azure-cost-governance");
+    expect(manifest).toBeDefined();
+    expect(manifest?.category).toBe("cloud");
+  });
+
   test("findPlugin returns undefined for unknown plugin", () => {
     expect(findPlugin("unknown-plugin")).toBeUndefined();
+  });
+
+  test("no duplicate plugin IDs", () => {
+    const plugins = loadRegistry();
+    const ids = plugins.map((p) => p.id);
+    const uniqueIds = new Set(ids);
+    expect(ids.length).toBe(uniqueIds.size);
   });
 });


### PR DESCRIPTION
The marketplace tools (marketplace_list_plugins, marketplace_search_plugins, marketplace_get_plugin) only loaded plugins from the registry/ directory (5 JSON files) and completely ignored the .claude-plugin/marketplace.json definition (94 plugins). This caused no plugins to appear after users added the marketplace and installed plugins.

Changes:
- types.ts: Add MarketplacePluginEntry and MarketplaceDefinition types, make PluginManifest fields optional for marketplace-sourced entries
- registry.ts: Load and merge plugins from both registry/ directory and marketplace.json, with deduplication (registry entries take precedence)
- index.ts: Add null-safe access for optional fields (tools, tags, category), enhance search to also match on tags and category
- registry.test.ts: Update tests to verify combined loading, deduplication, and marketplace-only plugin discovery

https://claude.ai/code/session_01J4YfTuYeHJEshvfma7VEGM