### PR TITLE
feat(teams-app-dev): upgrade to manifest v1.25 with meeting apps, message extensions, agents, and full 2026 platform alignment

### DIFF
--- a/teams-app-dev/.claude-plugin/plugin.json
+++ b/teams-app-dev/.claude-plugin/plugin.json
@@ -1,17 +1,21 @@
 {
   "name": "teams-app-dev",
-  "version": "1.0.0",
-  "description": "Custom Teams app development — Adaptive Cards, message extensions, bot handlers, tab apps, manifest authoring, and Teams Toolkit CLI workflows",
+  "version": "2.0.0",
+  "description": "Custom Teams app development — manifest v1.25, M365 Agents Toolkit, Adaptive Cards, message extensions, meeting apps, Custom Engine Agents, dialog orchestration, and Agent 365 blueprints",
   "author": {
     "name": "Markus Ahling"
   },
   "keywords": [
     "microsoft",
     "teams",
-    "teams-toolkit",
+    "m365-agents-toolkit",
     "adaptive-cards",
     "bot-framework",
     "message-extensions",
+    "meeting-apps",
+    "custom-engine-agents",
+    "agent-365",
+    "manifest-v1.25",
     "typescript"
   ],
   "skills": [
@@ -27,6 +31,10 @@
     "./commands/teams-message-extension.md",
     "./commands/teams-manifest.md",
     "./commands/teams-sideload.md",
-    "./commands/teams-bot-handler.md"
+    "./commands/teams-bot-handler.md",
+    "./commands/teams-agent.md",
+    "./commands/teams-dialog.md",
+    "./commands/teams-agent365.md",
+    "./commands/teams-migrate.md"
   ]
 }

--- a/teams-app-dev/README.md
+++ b/teams-app-dev/README.md
@@ -1,43 +1,62 @@
 # Teams App Dev Plugin
 
-Custom Microsoft Teams app development — build bots with Bot Framework, design Adaptive Cards, create message extensions (search/action/link unfurling), develop tab apps with SSO, author app manifests, and manage the full lifecycle with Teams Toolkit CLI.
+Custom Microsoft Teams app development for the 2026 platform — manifest v1.25, M365 Agents Toolkit CLI, Adaptive Cards (with mobile profiles), message extensions (bot-based and API-based), meeting apps (side panel, stage, content bubble), Custom Engine Agents, Agent 365 blueprints, Nested App Authentication (NAA), dialog namespace, and single-tenant bot registration.
 
 ## What This Plugin Provides
 
-This is a **knowledge plugin** — it gives Claude deep expertise in custom Teams app development so it can scaffold projects, generate Adaptive Cards, write bot handlers, create message extensions, author manifests, and guide sideloading. It does not contain runtime code, MCP servers, or executable scripts.
+This is a **knowledge plugin** — it gives Claude deep expertise in modern Teams app development so it can scaffold projects, generate Adaptive Cards, write bot handlers, create message extensions (including meeting-aware), author v1.25 manifests, build meeting apps, scaffold Custom Engine Agents and Agent 365 blueprints, and guide migration from legacy Teams Toolkit. It does not contain runtime code, MCP servers, or executable scripts.
 
 ## Setup
 
-Run `/setup` to install Teams Toolkit CLI and configure Azure Bot credentials:
+Run `/setup` to install M365 Agents Toolkit CLI and configure Azure Bot credentials:
 
 ```
-/setup              # Full guided setup
+/setup              # Full guided setup (single-tenant bot)
 /setup --minimal    # Dependencies only
 ```
 
-Requires an Azure Bot registration with Microsoft App ID and Client Secret.
+Requires an Azure Bot registration (single-tenant) with Microsoft App ID, Client Secret, and Tenant ID.
 
 ## Commands
 
 | Command | Description |
 |---------|-------------|
-| `/setup` | Install Teams Toolkit CLI, register Azure Bot, configure environment |
-| `/teams-scaffold` | Scaffold a Teams app project (bot, tab, or message extension) |
-| `/teams-adaptive-card` | Generate Adaptive Card JSON from a description |
-| `/teams-message-extension` | Scaffold a message extension handler with manifest fragment |
-| `/teams-manifest` | Generate or validate a Teams app manifest v1.17+ |
-| `/teams-sideload` | Package (ZIP) and sideload the app for testing |
-| `/teams-bot-handler` | Generate a TeamsActivityHandler with state, dialogs, proactive messaging |
+| `/setup` | Install M365 Agents Toolkit CLI, register Azure Bot (single-tenant), configure environment |
+| `/teams-scaffold` | Scaffold a Teams app project (bot, tab, message-extension, meeting-app, or custom-engine-agent) |
+| `/teams-adaptive-card` | Generate Adaptive Card JSON with optional meeting optimization and mobile profile |
+| `/teams-message-extension` | Scaffold a message extension (search, action, link unfurl, or meeting-aware) |
+| `/teams-manifest` | Generate or validate a Teams app manifest v1.25 |
+| `/teams-sideload` | Package and sideload the app, or test with Agents Playground |
+| `/teams-bot-handler` | Generate a TeamsActivityHandler with state, dialogs, proactive messaging, and meeting support |
+| `/teams-agent` | Scaffold a Custom Engine Agent with AI capabilities and tool calling |
+| `/teams-dialog` | Generate dialog orchestration code (replaces deprecated task modules) |
+| `/teams-agent365` | Create an Agent 365 blueprint with declarative manifest, identity, and MCP tools |
+| `/teams-migrate` | Migration guide from Teams Toolkit (TeamsFx) to M365 Agents Toolkit |
 
 ## Agent
 
 | Agent | Description |
 |-------|-------------|
-| **Teams App Reviewer** | Reviews Teams app projects for manifest correctness, Adaptive Card schema, bot patterns, message extension completeness, and security |
+| **Teams App Reviewer** | Reviews Teams app projects for manifest v1.25 correctness, single-tenant config, Adaptive Card schema (including mobile), bot patterns, message extension completeness, meeting app surfaces, auth/dialog patterns, and security |
+
+## Key Platform Changes (2026)
+
+- **Manifest**: v1.25 schema with `supportsChannelFeatures`, `nestedAppAuthInfo`, `backgroundLoadConfiguration`, `agenticUserTemplates`
+- **Tooling**: M365 Agents Toolkit CLI (`m365agents`) replaces Teams Toolkit CLI (`teamsapp`). Config: `m365agents.yml`
+- **Auth**: Single-tenant bot registration enforced (multi-tenant creation blocked since July 2025). NAA for pop-up-free tab SSO.
+- **Dialog namespace**: `dialog.url.open()` / `dialog.adaptiveCard.open()` replace deprecated `tasks.startTask()`
+- **TeamsJS**: v2.19.0+ required for submissions. v1 is blocked.
+- **Bot Framework SDK**: Archived December 2025. Use Teams SDK or Agents SDK for new projects.
+- **TeamsFx**: Deprecated (community-only until September 2026). Do not use for new projects.
+- **LUIS**: Fully retired March 31, 2026. Do not use.
+- **Adaptive Cards mobile**: v1.2 max on iOS/Android. Desktop/web supports v1.6.
+- **Message extensions**: Bot-based and API-based (OpenAPI, no bot needed) tracks available.
+- **Local testing**: Agents Playground (no bot registration or tunnel needed)
+- **SDK decision**: Teams SDK (Teams-only), Agents SDK (multi-channel), Agent 365 (enterprise governance overlay with JS/Python/.NET packages)
 
 ## Trigger Keywords
 
-The skill activates automatically when conversations mention: `teams app`, `teams toolkit`, `adaptive card`, `message extension`, `bot framework`, `teams bot`, `teams tab`, `teams manifest`, `sideload`, `teams sso`, `link unfurling`, `task module`.
+The skill activates automatically when conversations mention: `teams app`, `m365 agents toolkit`, `adaptive card`, `message extension`, `bot framework`, `teams bot`, `teams tab`, `teams manifest`, `sideload`, `teams sso`, `link unfurling`, `dialog`, `meeting app`, `meeting extension`, `custom engine agent`, `agent 365`, `agents playground`, `nested app auth`, `naa`.
 
 ## Author
 

--- a/teams-app-dev/agents/teams-app-reviewer.md
+++ b/teams-app-dev/agents/teams-app-reviewer.md
@@ -1,9 +1,9 @@
 ---
 name: Teams App Reviewer
 description: >
-  Reviews custom Teams app projects — validates manifest correctness, Adaptive Card schema compliance,
-  bot handler patterns, message extension completeness, and security best practices across the full
-  Teams app development stack.
+  Reviews custom Teams app projects — validates manifest v1.25 correctness, single-tenant bot configuration,
+  Adaptive Card schema compliance (including mobile compatibility), bot handler patterns, message extension
+  completeness, meeting app surfaces, dialog namespace usage, NAA configuration, and security best practices.
 model: inherit
 color: blue
 allowed-tools:
@@ -14,56 +14,87 @@ allowed-tools:
 
 # Teams App Reviewer Agent
 
-You are an expert Microsoft Teams app development reviewer. Analyze the provided Teams app project files and produce a structured review covering manifest, Adaptive Cards, bot handlers, message extensions, and security.
+You are an expert Microsoft Teams app development reviewer for the 2026 platform. Analyze the provided Teams app project files and produce a structured review covering manifest v1.25, Adaptive Cards, bot handlers, message extensions, meeting apps, auth, and security.
 
 ## Review Scope
 
-### 1. Manifest Correctness
+### 1. Manifest v1.25 Correctness
 
-- **Required fields**: Verify `$schema`, `manifestVersion`, `id`, `version`, `developer` (with `name`, `websiteUrl`, `privacyUrl`, `termsOfUseUrl`), `name` (`short`, `full`), `description` (`short`, `full`), `icons` (`color`, `outline`), `accentColor`.
-- **Valid GUIDs**: `id` and all `botId` values must be valid UUIDs (8-4-4-4-12 hex format). Flag placeholder values like `00000000-0000-0000-0000-000000000000`.
-- **validDomains**: Every external URL referenced in tabs, task modules, or web content must have its domain listed in `validDomains`. Flag missing domains.
-- **Bot ID consistency**: `bots[].botId` must match the `BOT_ID` environment variable and the Azure Bot registration. If `composeExtensions` is present, its `botId` must match `bots[].botId`.
-- **Icon dimensions**: `color.png` should be 192x192 and `outline.png` should be 32x32. Flag if icons are missing from the app package.
-- **Description lengths**: `name.short` max 30 chars, `description.short` max 80 chars, `description.full` max 4000 chars.
-- **Schema version**: Verify `manifestVersion` matches the `$schema` URL version (e.g., `1.17` schema with `"manifestVersion": "1.17"`).
+- **Required fields**: Verify `$schema`, `manifestVersion`, `id`, `version`, `developer`, `name`, `description`, `icons`, `accentColor`.
+- **Schema version**: `manifestVersion` must be `"1.25"`. Flag `"1.17"` or earlier as outdated with migration guidance. `$schema` URL must match the version.
+- **Valid GUIDs**: `id` and all `botId` values must be valid UUIDs. Flag placeholders like `00000000-0000-0000-0000-000000000000`.
+- **validDomains**: Every external URL in tabs/dialogs must have its domain listed.
+- **Bot ID consistency**: `bots[].botId` must match `composeExtensions[].botId`.
+- **Icon dimensions**: `color.png` = 192x192, `outline.png` = 32x32.
+- **Description lengths**: `name.short` max 30, `description.short` max 80, `description.full` max 4000.
+- **v1.25 new fields**:
+  - `supportsChannelFeatures` should be boolean (not string). Flag if missing on configurable tabs.
+  - `nestedAppAuthInfo`: if present, `accessTokenAcceptedVersion` must be `2`.
+  - `agenticUserTemplates`: each entry must have `id`, `title`, `description`, `prompt`.
+  - `backgroundLoadConfiguration`: if present, check `enabled` is boolean.
+- **Known v1.25 bugs**: Warn about regex validation bug and Dev Portal field persistence issues.
 
-### 2. Adaptive Card Schema
+### 2. Single-Tenant Bot Configuration
 
-- **Valid element types**: All `type` values must be valid Adaptive Card element types (`TextBlock`, `Image`, `Container`, `ColumnSet`, `Column`, `FactSet`, `Input.Text`, `Input.Number`, `Input.Date`, `Input.Time`, `Input.Toggle`, `Input.ChoiceSet`, `ActionSet`, `Table`, `RichTextBlock`).
-- **Action.Execute requirements**: Every `Action.Execute` must include a `verb` string. Flag `Action.Execute` without `verb`.
-- **Input IDs**: Every `Input.*` element must have a unique `id` property. Flag missing or duplicate `id` values.
-- **Version compatibility**: Cards using `Table`, `Icon`, or other v1.5+ elements should set `"version": "1.5"` or higher. Cards using only v1.4 elements should use `"version": "1.4"` for broader compatibility.
-- **Size limit**: Warn if card JSON payload exceeds 25 KB (approaching the 28 KB compressed limit).
-- **Fallback**: Cards using v1.5+ elements should include `fallbackText` or element-level `fallback` for older clients.
-- **Image URLs**: All image URLs must use HTTPS.
+- **Bot registration type**: Check that bot adapter uses `MicrosoftAppType: "SingleTenant"` with `MicrosoftAppTenantId`. Flag multi-tenant configuration as deprecated (creation blocked since July 2025).
+- **Bicep templates**: If `infra/` contains Bicep files, verify `msaAppType: 'SingleTenant'` and `msaAppTenantId` is set.
+- **Environment variables**: `.env` must include `APP_TENANTID`.
 
-### 3. Bot Handler Patterns
+### 3. Adaptive Card Schema
 
-- **Extends TeamsActivityHandler**: The bot class must extend `TeamsActivityHandler` (not plain `ActivityHandler`) to get Teams-specific method overrides.
-- **onTurnError configured**: The bot adapter must have `onTurnError` set to handle unhandled exceptions. Flag if missing.
-- **Welcome logic**: In `onMembersAdded`, the bot should check `member.id !== context.activity.recipient.id` to avoid welcoming itself.
-- **State management**: If the bot uses dialogs or stores data, verify `conversationState.saveChanges()` and `userState.saveChanges()` are called at the end of each turn.
-- **next() calls**: Verify that `onMessage`, `onMembersAdded`, and other handlers call `await next()` to allow middleware chain to continue.
-- **Proactive messaging**: If proactive messaging is used, verify conversation references are stored securely and the adapter uses `continueConversation`.
+- **Valid element types**: All `type` values must be valid Adaptive Card types.
+- **Action.Execute requirements**: Must include `verb` string.
+- **Input IDs**: Every `Input.*` must have unique `id`.
+- **Mobile compatibility**: Cards using v1.3+ elements (Table, Icon) should include `fallbackText` or element-level `fallback`. Warn about mobile v1.2 ceiling.
+- **Unsupported mobile features**: Flag `isEnabled` on `Action.Submit`, `style: "positive"/"destructive"`, file/image uploads.
+- **Size limit**: Warn if >25 KB (approaching 28 KB limit).
+- **Image URLs**: Must use HTTPS.
 
-### 4. Message Extension Completeness
+### 4. Bot Handler Patterns
 
-- **Handler-manifest alignment**: Every command in `composeExtensions[].commands` must have a corresponding handler in the bot:
-  - `type: "query"` → `handleTeamsMessagingExtensionQuery`
-  - `type: "action"` with `fetchTask: true` → `handleTeamsMessagingExtensionFetchTask` + `handleTeamsMessagingExtensionSubmitAction`
-- **Result cards**: Search results must include both a `content` card (full card) and a `preview` card (hero or thumbnail) for the result list.
-- **Parameters**: Query commands should define at least one `parameter` with a `name` and `description`.
-- **Link unfurling**: If `messageHandlers` with `type: "link"` is configured, verify `handleTeamsAppBasedLinkQuery` is implemented and domains are in `validDomains`.
+- **Extends TeamsActivityHandler**: Not plain `ActivityHandler`.
+- **onTurnError configured**: Adapter must have error handler.
+- **Welcome logic**: `onMembersAdded` should exclude bot itself.
+- **State management**: `saveChanges()` called at end of turn.
+- **next() calls**: All handlers must call `await next()`.
+- **Bot Framework SDK status**: If `botbuilder` < v4.22, warn that Bot Framework SDK is archived and recommend Teams SDK migration.
 
-### 5. Security
+### 5. Message Extension Completeness
 
-- **No hardcoded secrets**: Scan for hardcoded API keys, client secrets, passwords, or tokens in source files. Flag any string that looks like a secret (e.g., base64 strings > 20 chars near `secret`, `password`, `key`, `token` variables).
-- **.env in .gitignore**: Verify `.env` (and `.env.*`) is listed in `.gitignore`. Flag if missing.
-- **SSO token validation**: If tab SSO is used, verify the ID token is exchanged server-side via OBO flow — never use the raw SSO token to call Graph directly from the client.
-- **HTTPS in validDomains**: All `validDomains` entries must point to HTTPS-capable domains. Flag `localhost` entries (acceptable only in development).
-- **Bot password storage**: `BOT_PASSWORD` / `SECRET_BOT_PASSWORD` must be in environment variables or a key vault, never in source code.
-- **CORS configuration**: If the app has an Express/API backend, verify CORS is configured to allow only expected origins.
+- **Handler-manifest alignment**: Every `composeExtensions[].commands` must have a matching handler.
+- **Result cards**: Search results must include both `content` and `preview`.
+- **API-based extensions**: If `composeExtensionType: "apiBased"`, verify OpenAPI spec file exists and is referenced correctly.
+- **Link unfurling**: If `messageHandlers` configured, verify handler exists and domains are in `validDomains`.
+- **Meeting-aware extensions**: If meeting context is used, verify `channelData.meeting.id` detection.
+
+### 6. Meeting App Surfaces
+
+- **Manifest context**: Configurable tabs should include meeting contexts (`meetingSidePanel`, `meetingStage`, etc.).
+- **RSC permissions**: Meeting apps should include `OnlineMeeting.ReadBasic.Chat`, `MeetingStage.Write.Chat`.
+- **Content bubble**: If bot sends meeting notifications, verify `channelData.notification.alertInMeeting`.
+- **Stage sharing**: Verify `meeting.shareAppContentToStage` usage from side panel.
+
+### 7. Auth and Dialog Patterns
+
+- **TeamsJS version**: Must be >= 2.19.0 (v1 is submission-blocked). Check `package.json`.
+- **NAA configuration**: If `nestedAppAuthInfo` in manifest, verify MSAL.js usage with `supportsNestedAppAuth: true`.
+- **Dialog namespace**: Flag usage of deprecated `tasks.startTask()` or `tasks.submitTask()`. Recommend `dialog.url.open()` / `dialog.adaptiveCard.open()` / `dialog.url.submit()`.
+- **No LUIS**: Flag any LUIS imports or configuration (LUIS fully retired March 31, 2026).
+
+### 8. Security
+
+- **No hardcoded secrets**: Scan for API keys, passwords, tokens in source files.
+- **.env in .gitignore**: Verify `.env` files are git-ignored.
+- **SSO token validation**: If tab SSO, verify server-side OBO exchange (or NAA pattern).
+- **HTTPS in validDomains**: All entries must be HTTPS-capable.
+- **Bot password storage**: Must be in env vars or key vault, never in source.
+- **CORS configuration**: Verify CORS allows only expected origins.
+
+### 9. Tooling and Config
+
+- **Config file**: Should use `m365agents.yml` not `teamsapp.yml`. Flag legacy config.
+- **CLI references**: Flag `teamsapp` CLI references; recommend `m365agents`.
+- **TeamsFx imports**: Flag `@microsoft/teamsfx` imports (deprecated, community-only until Sept 2026).
 
 ## Output Format
 
@@ -71,18 +102,19 @@ You are an expert Microsoft Teams app development reviewer. Analyze the provided
 ## Teams App Review Summary
 
 **Overall**: [PASS / NEEDS WORK / CRITICAL ISSUES]
-**Files Reviewed**: [list of files]
+**Manifest Version**: [detected version]
+**Files Reviewed**: [list]
 
 ## Issues Found
 
 ### Critical
-- [ ] [Issue description with file path and line reference]
+- [ ] [Issue with file:line reference]
 
 ### Warnings
-- [ ] [Issue description with suggestion]
+- [ ] [Issue with suggestion]
 
 ### Suggestions
-- [ ] [Improvement suggestion]
+- [ ] [Improvement]
 
 ## What Looks Good
 - [Positive observations]

--- a/teams-app-dev/commands/teams-adaptive-card.md
+++ b/teams-app-dev/commands/teams-adaptive-card.md
@@ -1,7 +1,7 @@
 ---
 name: teams-adaptive-card
 description: "Generate an Adaptive Card JSON payload from a description, with optional data templating"
-argument-hint: "<description> [--template] [--version <1.4|1.5>]"
+argument-hint: "<description> [--template] [--version <1.4|1.5|1.6>] [--meeting]"
 allowed-tools:
   - Read
   - Write
@@ -18,58 +18,49 @@ Create an Adaptive Card JSON payload based on a natural-language description.
 
 ### 1. Parse the Request
 
-- `<description>` — What the card should display (e.g., "approval form with requester name, amount, and approve/reject buttons").
-- `--template` — When set, use Adaptive Card Templating syntax (`${field}`, `$data`, `$when`) so the card can be bound to dynamic data.
-- `--version` — Target schema version: `1.4` (broader compatibility) or `1.5` (Teams default, supports `Table`). Default: `1.5`.
+- `<description>` — What the card should display.
+- `--template` — Use Adaptive Card Templating syntax (`${field}`, `$data`, `$when`).
+- `--version` — Target schema version: `1.4` (Outlook), `1.5` (Teams mobile + desktop), or `1.6` (Teams desktop/web). Default: `1.5`.
+- `--meeting` — Optimize for meeting surfaces (content bubble, side panel). Uses compact layout.
 
 ### 2. Design the Card
-
-Based on the description, select appropriate elements:
 
 **Layout selection**:
 - Key-value data → `FactSet`
 - Side-by-side content → `ColumnSet` with `Column`s
 - Tabular data → `Table` (v1.5+) with `fallback` for older clients
 - Lists of items → `Container` with repeated elements (or `$data` loop if `--template`)
-- Images → `Image` or `ImageSet`
-
-**Input selection** (when the card collects data):
-- Free text → `Input.Text` (set `isMultiline` for long text)
-- Choices → `Input.ChoiceSet` (dropdown or radio)
-- Date/time → `Input.Date` / `Input.Time`
-- Yes/no → `Input.Toggle`
-- Numbers → `Input.Number`
 
 **Action selection**:
 - Submit data to a bot → `Action.Execute` with a `verb` (preferred for Teams)
 - Open a URL → `Action.OpenUrl`
 - Show additional content → `Action.ShowCard`
 
+**Meeting card optimizations** (when `--meeting`):
+- Use compact layout for content bubbles
+- Include `Action.Execute` for in-meeting voting or acknowledgment
+- Avoid large images or complex tables in content bubbles
+
 ### 3. Apply Templating (when --template)
 
-Wrap dynamic values in `${expression}` syntax:
 - Simple binding: `"text": "Hello, ${name}!"`
-- Array iteration: `"$data": "${items}"` on a `Container`
+- Array iteration: `"$data": "${items}"`
 - Conditional rendering: `"$when": "${status == 'active'}"`
-
-Generate a matching data schema that shows the expected shape of the `$root` object.
 
 ### 4. Validate the Card
 
-Check the generated card against these rules:
-- `type` is `"AdaptiveCard"` at root level.
-- `version` matches the requested version.
-- Every `Input.*` has a unique `id`.
-- Every `Action.Execute` has a `verb`.
-- Card JSON is under 28 KB.
-- All image URLs use HTTPS or are template placeholders.
-- Include `fallbackText` when using v1.5+ elements.
+- `type` is `"AdaptiveCard"` at root level
+- `version` matches the requested version
+- Every `Input.*` has a unique `id`
+- Every `Action.Execute` has a `verb`
+- Card JSON is under 28 KB
+- All image URLs use HTTPS
+- Include `fallbackText` when using v1.5+ elements
 
 ### 5. Output
 
-Write the card JSON to a file (e.g., `cards/<name>.json`) or display it inline. If `--template` was used, also output an example data object and the rendered result.
-
-Show the user how to use the card:
+Write the card JSON to a file or display inline. Show usage:
 - In a bot: `CardFactory.adaptiveCard(cardPayload)`
 - With templating: `new Template(cardPayload).expand({ $root: data })`
-- Testing: Paste into https://adaptivecards.io/designer/ with Host App set to "Microsoft Teams"
+- In a meeting content bubble: include `channelData.notification.alertInMeeting: true`
+- Testing: Paste into the Adaptive Cards Designer with Host App set to "Microsoft Teams"

--- a/teams-app-dev/commands/teams-agent.md
+++ b/teams-app-dev/commands/teams-agent.md
@@ -1,0 +1,111 @@
+---
+name: teams-agent
+description: "Scaffold a Custom Engine Agent with AI capabilities, tool calling, and Teams integration"
+argument-hint: "--name <agent-name> [--ai <openai|azure-openai|anthropic>] [--tools] [--rag]"
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Glob
+  - AskUserQuestion
+---
+
+# Scaffold a Custom Engine Agent
+
+Create a Custom Engine Agent project using the M365 Agents Toolkit with AI-powered conversational capabilities.
+
+## Instructions
+
+### 1. Validate Inputs
+
+- `--name` — Agent name (used for directory, manifest, and package.json). Ask if not provided.
+- `--ai` — AI provider: `openai`, `azure-openai`, or `anthropic`. Default: `azure-openai`.
+- `--tools` — When set, include function-calling tool definitions and execution scaffolding.
+- `--rag` — When set, include RAG (Retrieval-Augmented Generation) with Azure AI Search or SharePoint knowledge.
+
+### 2. Option A: Scaffold via M365 Agents Toolkit (Recommended)
+
+If M365 Agents Toolkit CLI is installed:
+
+```bash
+m365agents new --capability custom-engine-agent --app-name <agent-name>
+```
+
+### 3. Option B: Manual Scaffold
+
+Create the project structure:
+
+```
+<agent-name>/
+├── m365agents.yml
+├── m365agents.local.yml
+├── appPackage/
+│   ├── manifest.json        # v1.25 manifest with agenticUserTemplates
+│   ├── color.png
+│   └── outline.png
+├── src/
+│   ├── index.ts             # Express server with CloudAdapter (single-tenant)
+│   ├── agent.ts             # CustomEngineAgent class extending TeamsActivityHandler
+│   ├── aiClient.ts          # AI provider wrapper (OpenAI, Azure OpenAI, or Anthropic)
+│   ├── tools.ts             # Tool definitions and handlers (when --tools)
+│   └── knowledge.ts         # RAG retrieval service (when --rag)
+├── .env
+├── package.json
+└── tsconfig.json
+```
+
+**Agent class** (`src/agent.ts`):
+- Extend `TeamsActivityHandler`
+- In `onMessage`, route user messages through the AI client
+- Handle conversation history with a turn-scoped or state-managed message array
+- If `--tools`, include function-calling loop: send tools to AI, execute returned tool calls, feed results back
+- If `--rag`, prepend retrieved context to the system prompt before AI completion
+
+**AI client** (`src/aiClient.ts`):
+- For `azure-openai`: use `@azure/openai` SDK with `AZURE_OPENAI_ENDPOINT` and `AZURE_OPENAI_DEPLOYMENT`
+- For `openai`: use `openai` SDK with `OPENAI_API_KEY`
+- For `anthropic`: use `@anthropic-ai/sdk` with `ANTHROPIC_API_KEY`
+
+**Single-tenant adapter** (`src/index.ts`):
+```typescript
+const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
+  MicrosoftAppId: process.env.BOT_ID!,
+  MicrosoftAppPassword: process.env.BOT_PASSWORD!,
+  MicrosoftAppType: "SingleTenant",
+  MicrosoftAppTenantId: process.env.APP_TENANTID!,
+});
+```
+
+### 4. Generate Manifest v1.25
+
+Create `appPackage/manifest.json` with:
+- `$schema` pointing to v1.25
+- `manifestVersion`: `"1.25"`
+- Bot registration section with single-tenant enforcement
+- `agenticUserTemplates` with 2-3 starter prompt templates
+- `webApplicationInfo` for SSO
+- `nestedAppAuthInfo` for NAA
+
+### 5. Environment Configuration
+
+Generate `.env` with:
+```
+BOT_ID=
+BOT_PASSWORD=
+APP_TENANTID=
+AZURE_OPENAI_ENDPOINT=     # (azure-openai)
+AZURE_OPENAI_DEPLOYMENT=   # (azure-openai)
+AZURE_OPENAI_API_KEY=      # (azure-openai)
+OPENAI_API_KEY=            # (openai)
+ANTHROPIC_API_KEY=         # (anthropic)
+```
+
+### 6. Display Summary
+
+Show the user:
+- Created files and their purposes
+- AI provider configuration needed
+- How to test locally: `m365agents preview --local` (uses Agents Playground)
+- How to add tools and knowledge sources
+- Next steps: configure `.env`, test in Agents Playground

--- a/teams-app-dev/commands/teams-agent365.md
+++ b/teams-app-dev/commands/teams-agent365.md
@@ -1,0 +1,165 @@
+---
+name: teams-agent365
+description: "Create an Agent 365 blueprint with declarative manifest, identity configuration, and MCP tool integration"
+argument-hint: "--name <agent-name> [--tools <tool1,tool2>] [--knowledge <sharepoint|search>]"
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Glob
+  - AskUserQuestion
+---
+
+# Agent 365 Blueprint
+
+Create a declarative Agent 365 project with manifest-driven configuration, identity setup, and optional MCP tool integration.
+
+## Instructions
+
+### 1. Validate Inputs
+
+- `--name` — Agent display name (e.g., `Contoso Support Agent`). Ask if not provided.
+- `--tools` — Comma-separated list of MCP tool names to integrate. Optional.
+- `--knowledge` — Knowledge source: `sharepoint` (SharePoint site), `search` (Azure AI Search index). Optional.
+
+### 2. Scaffold the Agent 365 Project
+
+Create the project structure:
+
+```
+<agent-slug>/
+├── m365agents.yml
+├── appPackage/
+│   ├── manifest.json          # v1.25 manifest with agenticUserTemplates
+│   ├── agent-manifest.json    # Declarative agent manifest
+│   ├── color.png
+│   └── outline.png
+├── .env
+└── README.md
+```
+
+### 3. Generate the Agent Manifest
+
+Create `appPackage/agent-manifest.json`:
+
+```json
+{
+  "agentManifest": {
+    "id": "<agent-slug>",
+    "name": "<agent-name>",
+    "description": "<description from user>",
+    "instructions": "<system prompt — ask user for agent personality and scope>",
+    "capabilities": {
+      "tools": [],
+      "knowledge": { "sources": [] }
+    }
+  }
+}
+```
+
+**When `--tools` is provided**:
+Add MCP tool references:
+```json
+{
+  "tools": [
+    {
+      "type": "mcp",
+      "server": "<mcp-server-name>",
+      "tools": ["<tool1>", "<tool2>"]
+    }
+  ]
+}
+```
+
+Ask the user for the MCP server name and confirm which tools to expose.
+
+**When `--knowledge sharepoint`**:
+```json
+{
+  "knowledge": {
+    "sources": [
+      {
+        "type": "sharepoint",
+        "siteUrl": "https://<tenant>.sharepoint.com/sites/<site>"
+      }
+    ]
+  }
+}
+```
+
+Ask the user for the SharePoint site URL.
+
+**When `--knowledge search`**:
+```json
+{
+  "knowledge": {
+    "sources": [
+      {
+        "type": "azure-ai-search",
+        "endpoint": "https://<search-service>.search.windows.net",
+        "indexName": "<index-name>"
+      }
+    ]
+  }
+}
+```
+
+Ask the user for the search endpoint and index name.
+
+### 4. Generate the App Manifest v1.25
+
+Create `appPackage/manifest.json` with:
+- `$schema` pointing to v1.25
+- `manifestVersion`: `"1.25"`
+- `webApplicationInfo` for identity
+- `nestedAppAuthInfo` for NAA (pop-up-free auth)
+- `agenticUserTemplates` with starter prompts relevant to the agent's purpose
+- Bot section if the agent uses conversational interaction
+
+### 5. Generate Identity Configuration
+
+Set up Entra ID app registration requirements:
+- Single-tenant app registration
+- `api://<domain>/<client-id>` as Application ID URI
+- `access_as_user` delegated scope
+- Authorized Teams client IDs:
+  - `1fec8e78-bce4-4aaf-ab1b-5451cc387264` (desktop/mobile)
+  - `5e3ce6c0-2b1f-4285-8d4b-75ee78787346` (web)
+
+Create `.env` with required variables:
+```
+APP_TENANTID=
+AZURE_CLIENT_ID=
+AZURE_CLIENT_SECRET=
+```
+
+### 6. Generate Agentic User Templates
+
+Based on the agent's purpose, generate 2-4 prompt templates:
+
+```json
+{
+  "agenticUserTemplates": [
+    {
+      "id": "<template-id>",
+      "title": "<short title>",
+      "description": "<what this template does>",
+      "prompt": "<the actual prompt text>"
+    }
+  ]
+}
+```
+
+Ask the user what common tasks the agent should handle, then generate templates.
+
+### 7. Display Summary
+
+Show the user:
+- Created files and their purposes
+- How the agent manifest connects to the app manifest
+- Identity setup steps (Entra ID app registration)
+- MCP tool integration details (if tools provided)
+- Knowledge source configuration (if knowledge provided)
+- How to test: `m365agents preview --local` (Agents Playground)
+- How to deploy: `m365agents provision && m365agents deploy`

--- a/teams-app-dev/commands/teams-app-setup.md
+++ b/teams-app-dev/commands/teams-app-setup.md
@@ -1,6 +1,6 @@
 ---
 name: teams-app-setup
-description: Set up the Teams App Dev plugin — install Teams Toolkit CLI, register Azure Bot, configure BOT_ID and BOT_PASSWORD
+description: Set up the Teams App Dev plugin — install M365 Agents Toolkit CLI, register Azure Bot (single-tenant), configure BOT_ID, BOT_PASSWORD, and APP_TENANTID
 argument-hint: "[--minimal]"
 allowed-tools:
   - Read
@@ -14,13 +14,13 @@ allowed-tools:
 
 # Teams App Dev Setup
 
-Guide the user through setting up a Teams app development environment.
+Guide the user through setting up a Teams app development environment with the M365 Agents Toolkit.
 
 ## Step 1: Check Prerequisites
 
 Verify the following are installed:
 
-- **Node.js 18+**: Required for Teams Toolkit and Bot Framework.
+- **Node.js 18+**: Required for M365 Agents Toolkit and Bot Framework.
 - **npm**: Comes with Node.js.
 
 ```bash
@@ -28,11 +28,18 @@ node --version   # Must be >= 18.0.0
 npm --version
 ```
 
-## Step 2: Install Teams Toolkit CLI
+## Step 2: Install M365 Agents Toolkit CLI
+
+The M365 Agents Toolkit CLI (`m365agents`) replaces the legacy Teams Toolkit CLI (`teamsapp`).
 
 ```bash
-npm install -g @microsoft/teamsapp-cli
-teamsapp --version
+npm install -g @microsoft/m365agentstoolkit-cli
+m365agents --version
+```
+
+If the user has the legacy `@microsoft/teamsapp-cli` installed, recommend removing it:
+```bash
+npm uninstall -g @microsoft/teamsapp-cli
 ```
 
 ## Step 3: Install Bot Framework Dependencies
@@ -42,25 +49,29 @@ npm init -y && npm install botbuilder botbuilder-dialogs @microsoft/teams-js @az
 npm install --save-dev typescript @types/express @types/node ts-node
 ```
 
-## Step 4: Azure Bot Registration
+## Step 4: Azure Bot Registration (Single-Tenant)
+
+All v1.25 bot registrations enforce **single-tenant** authentication with `APP_TENANTID`.
 
 Ask the user to create (or provide) an Azure Bot resource:
 
 **Option A: Via Azure Portal**
 1. Go to Azure Portal > Create a resource > Azure Bot.
-2. Choose **Multi Tenant** for bot type.
-3. Select **Create new Microsoft App ID** (or use existing).
-4. Note the **Microsoft App ID** (this is `BOT_ID`) and create a **Client Secret** (this is `BOT_PASSWORD`).
-5. Under Configuration, set the Messaging endpoint to `https://<your-domain>/api/messages`.
+2. Choose **Single Tenant** for bot type.
+3. Set the **Tenant ID** to the organization's Entra ID tenant.
+4. Select **Create new Microsoft App ID** (or use existing).
+5. Note the **Microsoft App ID** (this is `BOT_ID`) and create a **Client Secret** (this is `BOT_PASSWORD`).
+6. Under Configuration, set the Messaging endpoint to `https://<your-domain>/api/messages`.
 
-**Option B: Via Teams Toolkit**
-Teams Toolkit can auto-create the bot registration during `teamsapp provision`. Skip this step if using Teams Toolkit for provisioning.
+**Option B: Via M365 Agents Toolkit**
+M365 Agents Toolkit can auto-create the bot registration during `m365agents provision`. Skip this step if using the toolkit for provisioning.
 
 **Option C: Via Azure CLI**
 ```bash
 az bot create --resource-group <rg-name> --name <bot-name> --kind registration \
   --endpoint "https://<your-domain>/api/messages" \
-  --microsoft-app-type MultiTenant \
+  --microsoft-app-type SingleTenant \
+  --microsoft-app-tenant-id <tenant-id> \
   --microsoft-app-id <app-id>
 ```
 
@@ -72,7 +83,7 @@ Create a `.env` file in the project root:
 BOT_ID=<microsoft-app-id>
 BOT_PASSWORD=<client-secret>
 BOT_ENDPOINT=https://<your-domain>
-AZURE_TENANT_ID=<your-tenant-id>
+APP_TENANTID=<your-tenant-id>
 AZURE_CLIENT_ID=<your-client-id>
 AZURE_CLIENT_SECRET=<your-client-secret>
 ```
@@ -84,14 +95,14 @@ echo ".env" >> .gitignore
 
 ## Step 6: Set Up Local Debugging
 
-For local development, Teams Toolkit uses dev tunnels:
+M365 Agents Toolkit includes the **Agents Playground** for local testing without bot registration:
 
 ```bash
-# Start local preview (creates tunnel + sideloads app)
-teamsapp preview --local
+# Start local preview with Agents Playground (no registration needed)
+m365agents preview --local
 ```
 
-Alternatively, use ngrok manually:
+For manual tunneling (full Teams client testing):
 ```bash
 npm install -g ngrok
 ngrok http 3978
@@ -108,6 +119,8 @@ Test the bot registration by sending a test message:
 npx ts-node src/index.ts
 ```
 
-Then sideload the app in Teams (see `/teams-sideload` command) and send a message to verify the bot responds.
+Then either:
+- Use Agents Playground (opened by `m365agents preview --local`)
+- Sideload the app in Teams (see `/teams-sideload` command) and send a message
 
 If `--minimal` is passed, stop after Step 3 (dependencies only).

--- a/teams-app-dev/commands/teams-bot-handler.md
+++ b/teams-app-dev/commands/teams-bot-handler.md
@@ -1,7 +1,7 @@
 ---
 name: teams-bot-handler
-description: "Generate a TeamsActivityHandler with optional state management, dialogs, and proactive messaging"
-argument-hint: "--name <BotClassName> [--dialogs] [--proactive] [--state <memory|blob|cosmos>]"
+description: "Generate a TeamsActivityHandler with optional state, dialogs, proactive messaging, and meeting support — single-tenant auth"
+argument-hint: "--name <BotClassName> [--dialogs] [--proactive] [--state <memory|blob|cosmos>] [--meeting]"
 allowed-tools:
   - Read
   - Write
@@ -13,16 +13,17 @@ allowed-tools:
 
 # Generate a Teams Bot Handler
 
-Create a `TeamsActivityHandler` subclass with configurable features.
+Create a `TeamsActivityHandler` subclass with configurable features and single-tenant authentication.
 
 ## Instructions
 
 ### 1. Validate Inputs
 
-- `--name` — Class name for the bot (e.g., `HelpDeskBot`, `ApprovalBot`). Ask if not provided.
+- `--name` — Class name for the bot. Ask if not provided.
 - `--dialogs` — Include WaterfallDialog setup with prompts.
-- `--proactive` — Include proactive messaging infrastructure (conversation reference storage + notification endpoint).
-- `--state` — State storage provider: `memory` (default, dev only), `blob` (Azure Blob Storage), `cosmos` (Cosmos DB).
+- `--proactive` — Include proactive messaging infrastructure.
+- `--state` — State storage: `memory` (default), `blob`, or `cosmos`.
+- `--meeting` — Include meeting-specific handlers (content bubble, stage sharing, meeting events).
 
 ### 2. Generate the Bot Class
 
@@ -30,49 +31,35 @@ Create `src/<botName>.ts` with:
 
 **Always included**:
 - Class extending `TeamsActivityHandler`
-- `onMessage` handler with basic command routing (`help`, unknown command fallback)
-- `onMembersAdded` handler that welcomes new users (excluding the bot itself)
-- Proper `await next()` calls in all handlers
+- `onMessage` handler with basic command routing
+- `onMembersAdded` handler (excludes bot itself)
+- Proper `await next()` calls
 
-**When --dialogs**:
-- Import `DialogSet`, `WaterfallDialog`, `TextPrompt`, `ChoicePrompt` from `botbuilder-dialogs`
-- Create a `DialogSet` with a sample `WaterfallDialog`
-- Route `onMessage` through `dialogContext.continueDialog()` / `dialogContext.beginDialog()`
-- Add dialog state accessor via `conversationState.createProperty("DialogState")`
-
-**When --proactive**:
-- Add a `conversationReferences` map to store conversation references
-- Save references in `onMessage` via `TurnContext.getConversationReference()`
-- Generate a `/api/notify` Express endpoint that sends a proactive message to all stored references
-
-**When --state is specified**:
-- `memory`: Use `MemoryStorage` (with a comment warning this is dev-only)
-- `blob`: Import `BlobsStorage` from `botbuilder-azure-blobs` with connection string from env
-- `cosmos`: Import `CosmosDbPartitionedStorage` from `botbuilder-azure` with connection config from env
+**When --dialogs**: DialogSet, WaterfallDialog, prompts
+**When --proactive**: Conversation reference storage, `/api/notify` endpoint
+**When --state**: Storage provider (MemoryStorage, BlobsStorage, or CosmosDb)
+**When --meeting**:
+- Meeting context detection from `channelData.meeting.id`
+- Content bubble notification method with `alertInMeeting: true`
+- Meeting stage sharing action handler via `onAdaptiveCardInvoke`
+- Meeting message extension handlers for agenda search and action items
 
 ### 3. Generate the Entry Point
 
-Create or update `src/index.ts` with:
-- Express server on port `process.env.PORT || 3978`
-- `CloudAdapter` with `onTurnError` error handler
-- Bot instance creation with state management
-- `POST /api/messages` route for the bot
-- `POST /api/notify` route (when `--proactive`)
-- State save middleware (when `--state` or `--dialogs`)
+Create or update `src/index.ts` with single-tenant `CloudAdapter`:
+```typescript
+const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
+  MicrosoftAppId: process.env.BOT_ID!,
+  MicrosoftAppPassword: process.env.BOT_PASSWORD!,
+  MicrosoftAppType: "SingleTenant",
+  MicrosoftAppTenantId: process.env.APP_TENANTID!,
+});
+```
 
 ### 4. Update Dependencies
 
-Check `package.json` and add any missing dependencies:
-- `botbuilder`, `botbuilder-dialogs` (when `--dialogs`)
-- `botbuilder-azure-blobs` (when `--state blob`)
-- `botbuilder-azure` (when `--state cosmos`)
-- `express`, `dotenv`
+Check `package.json` and add any missing dependencies.
 
 ### 5. Display Summary
 
-Show the user:
-- Created/updated files
-- Bot capabilities (message handling, dialogs, proactive messaging, state)
-- How to run: `npx ts-node src/index.ts`
-- How to test: `/teams-sideload` or `teamsapp preview --local`
-- Reminder to configure `.env` with `BOT_ID` and `BOT_PASSWORD`
+Show created files, capabilities, how to run/test, and `.env` configuration reminder.

--- a/teams-app-dev/commands/teams-dialog.md
+++ b/teams-app-dev/commands/teams-dialog.md
@@ -1,0 +1,104 @@
+---
+name: teams-dialog
+description: "Generate dialog orchestration code replacing deprecated task modules — uses dialog.url.open() and dialog.adaptiveCard.open()"
+argument-hint: "<url|adaptive-card> --name <dialog-name> [--bot-handler]"
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Glob
+  - AskUserQuestion
+---
+
+# Dialog Orchestration (Replaces Task Modules)
+
+Generate dialog code using the `dialog` namespace from Teams JS SDK v2, replacing the deprecated `tasks` namespace.
+
+## Instructions
+
+### 1. Validate Inputs
+
+- `<type>` — One of: `url`, `adaptive-card`. Ask if not provided.
+- `--name` — Dialog identifier (e.g., `feedbackDialog`, `createItemDialog`). Ask if not provided.
+- `--bot-handler` — When set, also generate the bot-side `handleTeamsTaskModuleFetch` and `handleTeamsTaskModuleSubmit` handlers.
+
+### 2. Explain the Migration
+
+Inform the user:
+- The `tasks` namespace (`tasks.startTask()`, `tasks.submitTask()`) is **deprecated**
+- The replacement is the `dialog` namespace:
+  - `dialog.url.open()` replaces `tasks.startTask()` with a URL
+  - `dialog.adaptiveCard.open()` replaces `tasks.startTask()` with a card
+  - `dialog.url.submit()` replaces `tasks.submitTask()` from inside a dialog iframe
+- The bot-side handlers remain `handleTeamsTaskModuleFetch` / `handleTeamsTaskModuleSubmit` (method names unchanged)
+
+### 3. Generate Client-Side Code
+
+**For `url` type**:
+Create a TypeScript module that:
+- Imports `dialog` and `app` from `@microsoft/teams-js`
+- Calls `app.initialize()` before any SDK use
+- Opens the dialog with `dialog.url.open()` specifying `url`, `title`, `size`, and `fallbackUrl`
+- Handles the callback result (parse JSON string from `result.result`)
+- Creates the dialog content page with a form and `dialog.url.submit()` to close
+
+**For `adaptive-card` type**:
+Create a TypeScript module that:
+- Imports `dialog` and `app` from `@microsoft/teams-js`
+- Calls `app.initialize()`
+- Builds an Adaptive Card JSON with input fields based on user requirements
+- Opens with `dialog.adaptiveCard.open()` specifying `card` (stringified), `title`, `size`
+- Handles the callback result
+
+Ask the user what form fields to include in the dialog.
+
+### 4. Generate Bot-Side Handlers (when --bot-handler)
+
+Create or update the bot class with:
+
+```typescript
+protected async handleTeamsTaskModuleFetch(
+  context: TurnContext,
+  taskModuleRequest: { data: Record<string, string> }
+) {
+  return {
+    task: {
+      type: "continue",
+      value: {
+        title: "<dialog-name>",
+        height: 450,
+        width: 500,
+        card: CardFactory.adaptiveCard({...}),
+      },
+    },
+  };
+}
+
+protected async handleTeamsTaskModuleSubmit(
+  context: TurnContext,
+  taskModuleRequest: { data: Record<string, string> }
+) {
+  // Process submitted data
+  return { task: { type: "message", value: "Success" } };
+}
+```
+
+### 5. Update Manifest (if applicable)
+
+If the dialog is triggered from a bot card action:
+- Ensure the bot section exists in `manifest.json`
+- If triggered from `Action.Submit` with `{ "type": "task/fetch" }`, the bot handler chain activates automatically
+
+### 6. Display Summary
+
+Show the user:
+- Generated files and key functions
+- The deprecated → new API mapping:
+  | Deprecated | New |
+  |-----------|-----|
+  | `tasks.startTask(taskInfo)` | `dialog.url.open(urlDialogInfo)` or `dialog.adaptiveCard.open(cardDialogInfo)` |
+  | `tasks.submitTask(result)` | `dialog.url.submit(result)` |
+  | `tasks.updateTask(taskInfo)` | Not yet available — use card refresh pattern |
+- How to test the dialog in Teams
+- Bot handler method names remain unchanged (`handleTeamsTaskModuleFetch` / `handleTeamsTaskModuleSubmit`)

--- a/teams-app-dev/commands/teams-manifest.md
+++ b/teams-app-dev/commands/teams-manifest.md
@@ -1,6 +1,6 @@
 ---
 name: teams-manifest
-description: "Generate or validate a Teams app manifest (v1.17+)"
+description: "Generate or validate a Teams app manifest v1.25 — includes supportsChannelFeatures, nestedAppAuthInfo, backgroundLoadConfiguration, agenticUserTemplates"
 argument-hint: "[--validate] [--generate] [--path <manifest-path>]"
 allowed-tools:
   - Read
@@ -12,9 +12,9 @@ allowed-tools:
   - AskUserQuestion
 ---
 
-# Teams App Manifest
+# Teams App Manifest v1.25
 
-Generate a new `manifest.json` or validate an existing one against the Teams app manifest schema v1.17+.
+Generate a new `manifest.json` or validate an existing one against the Teams app manifest schema v1.25.
 
 ## Instructions
 
@@ -26,21 +26,29 @@ Ask the user for:
 - **App name** (short and full)
 - **Description** (short ≤80 chars, full ≤4000 chars)
 - **Developer info** (name, website URL, privacy URL, terms URL)
-- **App capabilities** — which of: bot, message extension, static tab, configurable tab
-- **Bot ID** (if bot/message extension) — or use `{{BOT_ID}}` placeholder for Teams Toolkit
+- **App capabilities** — which of: bot, message extension, static tab, configurable tab, meeting app, custom engine agent
+- **Bot ID** (if bot/message extension) — or use `{{BOT_ID}}` placeholder for M365 Agents Toolkit
+- **Tenant ID** — required for single-tenant bot registration (`APP_TENANTID`)
 - **Hosting domain** (for `validDomains`)
-- **SSO** — whether to include `webApplicationInfo` section
+- **SSO** — whether to include `webApplicationInfo` and `nestedAppAuthInfo` (NAA)
+- **Meeting app** — whether to include meeting context scopes
+- **Agent templates** — whether to include `agenticUserTemplates`
 
 #### 2. Generate Manifest
 
 Create `appPackage/manifest.json` with:
-- `$schema` pointing to the v1.17 schema
-- `manifestVersion`: `"1.17"`
-- `id`: `"{{APP_ID}}"` (Teams Toolkit placeholder) or a generated UUID
+- `$schema` pointing to v1.25 schema
+- `manifestVersion`: `"1.25"`
+- `id`: `"{{APP_ID}}"` (M365 Agents Toolkit placeholder) or a generated UUID
 - All required developer, name, description, and icon fields
-- Capability-specific sections (`bots`, `composeExtensions`, `staticTabs`, `configurableTabs`)
+- Capability-specific sections (bots, composeExtensions, staticTabs, configurableTabs)
 - `validDomains` with the hosting domain
 - `webApplicationInfo` if SSO is requested
+- `nestedAppAuthInfo` if NAA is requested
+- `backgroundLoadConfiguration` if preloading is desired
+- `agenticUserTemplates` if agent templates are requested
+- `supportsChannelFeatures: true` on configurable tabs
+- `authorization.permissions.resourceSpecific` for RSC permissions
 
 #### 3. Create Placeholder Icons
 
@@ -56,15 +64,17 @@ Find `manifest.json` at the provided `--path` or search in `appPackage/manifest.
 
 #### 2. Run Schema Validation
 
-If Teams Toolkit is installed:
+If M365 Agents Toolkit is installed:
 ```bash
-teamsapp validate --manifest-path <path>
+m365agents validate --manifest-path <path>
 ```
 
 #### 3. Run Additional Checks
 
-Regardless of Teams Toolkit availability, check:
+Check:
 - All required fields are present and non-empty
+- `manifestVersion` is `"1.25"` (warn if using older schema)
+- `$schema` URL matches `manifestVersion` value
 - `id` and all `botId` values are valid UUIDs (not placeholder zeros)
 - `name.short` ≤ 30 chars, `description.short` ≤ 80 chars, `description.full` ≤ 4000 chars
 - `icons.color` and `icons.outline` files exist in the same directory
@@ -72,14 +82,15 @@ Regardless of Teams Toolkit availability, check:
 - `composeExtensions[].botId` matches `bots[].botId` (if both exist)
 - No `http://` URLs (must be HTTPS) except `localhost` for dev
 - `accentColor` is a valid hex color (#RRGGBB)
+- **v1.25-specific checks**:
+  - `nestedAppAuthInfo.accessTokenAcceptedVersion` is `2` (not `1`)
+  - `agenticUserTemplates` entries have `id`, `title`, `description`, and `prompt`
+  - `configurableTabs` with meeting contexts include appropriate RSC permissions
+  - `supportsChannelFeatures` is boolean (not string)
+- **Known v1.25 bug checks**:
+  - Warn if `Input.Text.regex` patterns are used (validator may reject valid regex)
+  - Warn that Dev Portal may drop `nestedAppAuthInfo` on save
 
 #### 4. Report Results
 
-Display a table of validation results:
-| Check | Status | Details |
-|-------|--------|---------|
-| Required fields | PASS/FAIL | List missing fields |
-| GUID validity | PASS/FAIL | List invalid GUIDs |
-| ... | ... | ... |
-
-Provide fix suggestions for any failures.
+Display a table of validation results with fix suggestions for any failures.

--- a/teams-app-dev/commands/teams-message-extension.md
+++ b/teams-app-dev/commands/teams-message-extension.md
@@ -1,7 +1,7 @@
 ---
 name: teams-message-extension
-description: "Scaffold a message extension handler (search, action, or link unfurling) with manifest fragment"
-argument-hint: "<search|action|link-unfurl> --name <command-name>"
+description: "Scaffold a message extension handler (search, action, link unfurling, or meeting-aware) with manifest v1.25 fragment"
+argument-hint: "<search|action|link-unfurl|meeting> --name <command-name>"
 allowed-tools:
   - Read
   - Write
@@ -13,14 +13,14 @@ allowed-tools:
 
 # Scaffold a Message Extension
 
-Generate a message extension handler and the corresponding manifest fragment.
+Generate a message extension handler and the corresponding manifest v1.25 fragment.
 
 ## Instructions
 
 ### 1. Validate Inputs
 
-- `<type>` — One of: `search`, `action`, `link-unfurl`. Ask if not provided.
-- `--name` — Command name/ID (e.g., `searchProducts`, `createTicket`). Ask if not provided.
+- `<type>` — One of: `search`, `action`, `link-unfurl`, `meeting`. Ask if not provided.
+- `--name` — Command name/ID (e.g., `searchProducts`, `createTicket`, `meetingAgenda`). Ask if not provided.
 
 ### 2. Generate the Handler
 
@@ -31,84 +31,43 @@ Create a `handleTeamsMessagingExtensionQuery` method that:
 - Maps results to Adaptive Card attachments with both `content` and `preview` cards
 - Returns a `MessagingExtensionResponse` with `type: "result"` and `attachmentLayout: "list"`
 
-Ask the user what data source to search (describe the expected result fields).
-
 **For `action` type**:
 Create two methods:
-1. `handleTeamsMessagingExtensionFetchTask` — Returns a task module with an Adaptive Card form
-2. `handleTeamsMessagingExtensionSubmitAction` — Processes the submitted form data and returns a result card
-
-Ask the user what form fields to include and what happens on submit.
+1. `handleTeamsMessagingExtensionFetchTask` — Returns a dialog with an Adaptive Card form
+2. `handleTeamsMessagingExtensionSubmitAction` — Processes the submitted form data
 
 **For `link-unfurl` type**:
 Create a `handleTeamsAppBasedLinkQuery` method that:
 - Extracts the URL from `query.url`
 - Fetches metadata for the URL
-- Returns a thumbnail or hero card with title, description, and image
+- Returns a thumbnail or hero card
 
-Ask the user which domains to unfurl.
+**For `meeting` type**:
+Create a meeting-aware message extension that:
+- Detects meeting context from `context.activity.channelData?.meeting?.id`
+- Adapts search results based on meeting context
+- Creates action items linked to the meeting
+- Uses both `handleTeamsMessagingExtensionQuery` and submit/fetch handlers
 
-### 3. Generate the Manifest Fragment
+### 3. Generate the Manifest v1.25 Fragment
 
-Produce the `composeExtensions` JSON to merge into `manifest.json`:
+Produce the `composeExtensions` JSON to merge into `manifest.json` (v1.25).
 
-**Search**:
-```json
-{
-  "composeExtensions": [{
-    "botId": "{{BOT_ID}}",
-    "commands": [{
-      "id": "<command-name>",
-      "type": "query",
-      "title": "<Title>",
-      "description": "<Description>",
-      "initialRun": true,
-      "parameters": [{ "name": "query", "title": "Search", "description": "<what to search>" }]
-    }]
-  }]
-}
-```
-
-**Action**:
-```json
-{
-  "composeExtensions": [{
-    "botId": "{{BOT_ID}}",
-    "commands": [{
-      "id": "<command-name>",
-      "type": "action",
-      "title": "<Title>",
-      "description": "<Description>",
-      "context": ["message", "compose"],
-      "fetchTask": true
-    }]
-  }]
-}
-```
-
-**Link unfurl**:
-```json
-{
-  "composeExtensions": [{
-    "botId": "{{BOT_ID}}",
-    "messageHandlers": [{
-      "type": "link",
-      "value": { "domains": ["<domain1>", "<domain2>"] }
-    }]
-  }]
-}
-```
+**Meeting** type generates both search + action commands for agenda search and action item creation.
 
 ### 4. Update Manifest
 
-If `appPackage/manifest.json` exists, merge the `composeExtensions` section into it. If `composeExtensions` already exists, append the new command to the existing array.
-
-Also add any new domains to `validDomains`.
+If `appPackage/manifest.json` exists:
+- Verify it uses v1.25 schema (warn if older)
+- Merge the `composeExtensions` section
+- Add any new domains to `validDomains`
+- For meeting extensions, ensure `configurableTabs` include meeting context scopes
 
 ### 5. Display Summary
 
 Show the user:
 - Generated handler file path and key methods
 - Manifest fragment that was added
-- How to test the extension in Teams
+- How to test the extension in Teams or Agents Playground
+- For meeting extensions: how to test in a scheduled meeting
 - Reminder to register the bot if not already done (`/setup`)

--- a/teams-app-dev/commands/teams-migrate.md
+++ b/teams-app-dev/commands/teams-migrate.md
@@ -1,0 +1,202 @@
+---
+name: teams-migrate
+description: "Migration guide from Teams Toolkit (TeamsFx) to M365 Agents Toolkit — manifest v1.17→v1.25, teamsapp→m365agents, multi-tenant→single-tenant"
+argument-hint: "[--path <project-root>] [--dry-run]"
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Glob
+  - Grep
+  - AskUserQuestion
+---
+
+# Migrate to M365 Agents Toolkit
+
+Guide migration of an existing Teams Toolkit (TeamsFx) project to the M365 Agents Toolkit with manifest v1.25, single-tenant auth, and the new dialog namespace.
+
+## Instructions
+
+### 1. Analyze the Existing Project
+
+Scan the project at `--path` (default: current directory) for:
+- `teamsapp.yml` / `teamsapp.local.yml` — legacy config files
+- `appPackage/manifest.json` — current manifest version
+- `package.json` — dependencies including `@microsoft/teamsapp-cli`, `botbuilder` versions
+- `.env*` files — environment variable structure
+- Source files — usage of deprecated APIs (`tasks.startTask`, `tasks.submitTask`, multi-tenant adapter config)
+
+If `--dry-run` is set, only report what would change without modifying files.
+
+### 2. Report Migration Scope
+
+Display a migration assessment:
+
+| Area | Current | Target | Changes Required |
+|------|---------|--------|-----------------|
+| CLI | `@microsoft/teamsapp-cli` | `@microsoft/m365agentstoolkit-cli` | Reinstall CLI |
+| Config file | `teamsapp.yml` | `m365agents.yml` | Rename + update version |
+| Manifest schema | v1.17 (or earlier) | v1.25 | Update schema URL and version |
+| Bot auth | Multi-tenant | Single-tenant | Add `APP_TENANTID`, update adapter |
+| Task modules | `tasks` namespace | `dialog` namespace | Update client-side code |
+| Bot registration | MultiTenant | SingleTenant | Update Azure Bot + Bicep |
+
+### 3. Migrate CLI and Config (Step 1)
+
+```bash
+# Uninstall legacy CLI
+npm uninstall -g @microsoft/teamsapp-cli
+
+# Install M365 Agents Toolkit CLI
+npm install -g @microsoft/m365agentstoolkit-cli
+```
+
+Rename config files:
+- `teamsapp.yml` → `m365agents.yml`
+- `teamsapp.local.yml` → `m365agents.local.yml`
+
+Update the version field in the YAML:
+```yaml
+# Before
+version: v1.4
+
+# After
+version: v1.6
+```
+
+### 4. Migrate Manifest to v1.25 (Step 2)
+
+Update `appPackage/manifest.json`:
+
+```diff
+- "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.17/MicrosoftTeams.schema.json",
+- "manifestVersion": "1.17",
++ "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.25/MicrosoftTeams.schema.json",
++ "manifestVersion": "1.25",
+```
+
+Add new v1.25 fields as applicable:
+- `supportsChannelFeatures: true` on configurable tabs
+- `nestedAppAuthInfo` for NAA (if SSO is used)
+- `backgroundLoadConfiguration` (optional)
+- `agenticUserTemplates` (if building agent-like experiences)
+
+**Known v1.25 bugs to warn about**:
+1. Regex validation may reject valid patterns — validate locally
+2. Dev Portal may drop `nestedAppAuthInfo` on save — author in codebase only
+
+### 5. Migrate to Single-Tenant Auth (Step 3)
+
+**Update `.env`**:
+```diff
+  BOT_ID=<app-id>
+  BOT_PASSWORD=<secret>
++ APP_TENANTID=<tenant-id>
+```
+
+**Update bot adapter** in `src/index.ts`:
+```diff
+- const adapter = new CloudAdapter();
++ const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
++   MicrosoftAppId: process.env.BOT_ID!,
++   MicrosoftAppPassword: process.env.BOT_PASSWORD!,
++   MicrosoftAppType: "SingleTenant",
++   MicrosoftAppTenantId: process.env.APP_TENANTID!,
++ });
++ const botFrameworkAuthentication = new ConfigurationBotFrameworkAuthentication({}, credentialsFactory);
++ const adapter = new CloudAdapter(botFrameworkAuthentication);
+```
+
+**Update Bicep templates** (`infra/`):
+```diff
+  properties: {
+    msaAppId: botAadAppClientId
+-   msaAppType: 'MultiTenant'
++   msaAppType: 'SingleTenant'
++   msaAppTenantId: appTenantId
+  }
+```
+
+**Update Azure Bot resource** (if already deployed):
+- Azure Portal > Bot resource > Configuration > Microsoft App Type → Single Tenant
+- Set the Tenant ID
+
+### 6. Migrate Task Modules to Dialog Namespace (Step 4)
+
+Search for deprecated `tasks` namespace usage:
+
+```bash
+grep -rn "tasks.startTask\|tasks.submitTask\|tasks.updateTask" src/
+```
+
+Replace each occurrence:
+
+| Deprecated | Replacement |
+|-----------|-------------|
+| `microsoftTeams.tasks.startTask(taskInfo, callback)` | `dialog.url.open(dialogInfo, callback)` or `dialog.adaptiveCard.open(cardInfo, callback)` |
+| `microsoftTeams.tasks.submitTask(result)` | `dialog.url.submit(result)` |
+| `import { tasks } from "@microsoft/teams-js"` | `import { dialog } from "@microsoft/teams-js"` |
+
+**Note**: Bot-side handlers (`handleTeamsTaskModuleFetch`, `handleTeamsTaskModuleSubmit`) do NOT need renaming — only the client-side code changes.
+
+### 7. Update Dependencies (Step 5)
+
+```bash
+# Update bot framework packages
+npm install botbuilder@latest botbuilder-dialogs@latest
+
+# Update Teams JS SDK (ensure v2.19+ for dialog namespace)
+npm install @microsoft/teams-js@latest
+
+# Remove legacy references
+npm uninstall @microsoft/teamsfx  # if present
+```
+
+### 8. Update CI/CD (Step 6)
+
+Search for `teamsapp` references in CI/CD files:
+
+```bash
+grep -rn "teamsapp\|@microsoft/teamsapp-cli" .github/ azure-pipelines.yml
+```
+
+Replace:
+- `npm install -g @microsoft/teamsapp-cli` → `npm install -g @microsoft/m365agentstoolkit-cli`
+- `teamsapp provision` → `m365agents provision`
+- `teamsapp deploy` → `m365agents deploy`
+- `teamsapp publish` → `m365agents publish`
+- `teamsapp validate` → `m365agents validate`
+
+### 9. Validate Migration
+
+```bash
+# Validate the updated manifest
+m365agents validate --manifest-path ./appPackage/manifest.json
+
+# Test locally with Agents Playground
+m365agents preview --local
+
+# Run existing tests
+npm test
+```
+
+### 10. Display Migration Report
+
+Show a summary table:
+
+| Step | Status | Details |
+|------|--------|---------|
+| CLI migration | DONE/SKIPPED | Installed `m365agentstoolkit-cli` |
+| Config rename | DONE/SKIPPED | `teamsapp.yml` → `m365agents.yml` |
+| Manifest v1.25 | DONE/SKIPPED | Updated schema + new fields |
+| Single-tenant | DONE/SKIPPED | Added `APP_TENANTID`, updated adapter |
+| Dialog namespace | DONE/SKIPPED | Migrated N occurrences |
+| Dependencies | DONE/SKIPPED | Updated packages |
+| CI/CD | DONE/SKIPPED | Updated pipeline references |
+
+List any manual steps the user must complete:
+- Update Azure Bot resource tenancy in Azure Portal
+- Reconfigure OAuth connections for single-tenant
+- Update Entra ID app registration redirect URIs
+- Test in Teams after sideloading the updated package

--- a/teams-app-dev/commands/teams-scaffold.md
+++ b/teams-app-dev/commands/teams-scaffold.md
@@ -1,7 +1,7 @@
 ---
 name: teams-scaffold
-description: "Scaffold a new Teams app project by type (bot, tab, or message extension)"
-argument-hint: "<bot|tab|message-extension> --name <app-name>"
+description: "Scaffold a new Teams app project by type (bot, tab, message-extension, meeting-app, or custom-engine-agent)"
+argument-hint: "<bot|tab|message-extension|meeting-app|custom-engine-agent> --name <app-name>"
 allowed-tools:
   - Read
   - Write
@@ -13,47 +13,49 @@ allowed-tools:
 
 # Scaffold a Teams App Project
 
-Create a new Teams app project with all required files based on the app type.
+Create a new Teams app project with all required files based on the app type, using manifest v1.25 and M365 Agents Toolkit.
 
 ## Instructions
 
 ### 1. Validate Inputs
 
-- `<type>` — One of: `bot`, `tab`, `message-extension`. Ask if not provided.
+- `<type>` — One of: `bot`, `tab`, `message-extension`, `meeting-app`, `custom-engine-agent`. Ask if not provided.
 - `--name` — App name (used for directory, manifest, and package.json). Ask if not provided.
 
-### 2. Option A: Scaffold via Teams Toolkit (Recommended)
+### 2. Option A: Scaffold via M365 Agents Toolkit (Recommended)
 
-If Teams Toolkit CLI is installed, use it for scaffolding:
+If M365 Agents Toolkit CLI is installed, use it for scaffolding:
 
 ```bash
-teamsapp new --app-name <app-name> --capability <type>
+m365agents new --app-name <app-name> --capability <type>
 ```
 
 Capability mapping:
-| Input | Teams Toolkit capability |
-|-------|-------------------------|
+| Input | M365 Agents Toolkit capability |
+|-------|-------------------------------|
 | `bot` | `bot` |
 | `tab` | `tab-non-sso` or `tab` (with SSO) |
 | `message-extension` | `search-message-extension` or `action-message-extension` |
+| `meeting-app` | `tab` with meeting context scopes |
+| `custom-engine-agent` | `custom-engine-agent` |
 
 Ask the user which sub-type they want if relevant.
 
 ### 3. Option B: Manual Scaffold
 
-If Teams Toolkit is not installed, create the project manually.
+If M365 Agents Toolkit is not installed, create the project manually.
 
 **Common files (all types)**:
 - `package.json` — Dependencies for the chosen type
 - `tsconfig.json` — TypeScript configuration
-- `.env` — Environment variables template
+- `.env` — Environment variables template (includes `APP_TENANTID` for single-tenant)
 - `.gitignore` — Includes `.env`, `node_modules/`, `dist/`, `appPackage/build/`
-- `appPackage/manifest.json` — App manifest with placeholder GUIDs
+- `appPackage/manifest.json` — App manifest v1.25 with placeholder GUIDs
 - `appPackage/color.png` — Placeholder 192x192 icon (instruct user to replace)
 - `appPackage/outline.png` — Placeholder 32x32 icon (instruct user to replace)
 
 **Bot-specific files**:
-- `src/index.ts` — Express server with `CloudAdapter` and bot setup
+- `src/index.ts` — Express server with `CloudAdapter` and single-tenant auth
 - `src/teamsBot.ts` — `TeamsActivityHandler` with `onMessage` and `onMembersAdded`
 
 **Tab-specific files**:
@@ -62,16 +64,34 @@ If Teams Toolkit is not installed, create the project manually.
 - `public/index.html` — HTML shell
 
 **Message extension files**:
-- `src/index.ts` — Express server with adapter
+- `src/index.ts` — Express server with single-tenant adapter
 - `src/searchBot.ts` — Bot with `handleTeamsMessagingExtensionQuery`
 
-### 4. Generate Manifest
+**Meeting app files**:
+- `src/index.ts` — Express server with single-tenant adapter
+- `src/meetingBot.ts` — Bot with meeting notification handlers
+- `src/components/SidePanel.tsx` — Meeting side panel with stage sharing
+- `src/components/Stage.tsx` — Meeting stage content component
+
+**Custom Engine Agent files**:
+- `src/index.ts` — Express server with single-tenant adapter
+- `src/agent.ts` — Agent class with AI client integration
+- `src/aiClient.ts` — AI provider wrapper
+
+### 4. Generate Manifest v1.25
 
 Create `appPackage/manifest.json` with:
-- `id`: `"{{APP_ID}}"` (placeholder for Teams Toolkit) or a generated UUID
-- `botId`: `"{{BOT_ID}}"` for bot and message extension types
-- Appropriate `bots`, `composeExtensions`, `staticTabs`, or `configurableTabs` section
-- `validDomains` including the app's hosting domain
+- `$schema` pointing to v1.25: `https://developer.microsoft.com/json-schemas/teams/v1.25/MicrosoftTeams.schema.json`
+- `manifestVersion`: `"1.25"`
+- `id`: `"{{APP_ID}}"` (placeholder for M365 Agents Toolkit) or a generated UUID
+- `botId`: `"{{BOT_ID}}"` for bot, message extension, and meeting app types
+- Single-tenant bot configuration
+- Appropriate `bots`, `composeExtensions`, `staticTabs`, `configurableTabs` sections
+- For meeting apps: `configurableTabs` with `context` including `meetingSidePanel`, `meetingStage`, `meetingDetailsTab`
+- `validDomains` with the hosting domain
+- `webApplicationInfo` if SSO is requested
+- `nestedAppAuthInfo` for NAA support
+- `supportsChannelFeatures: true` on configurable tabs
 
 ### 5. Initialize and Install
 
@@ -84,5 +104,6 @@ npm install
 
 Show the user:
 - Created files and their purposes
-- Next steps (configure `.env`, run `/setup`, test with `/teams-sideload`)
+- Next steps (configure `.env` with `BOT_ID`, `BOT_PASSWORD`, `APP_TENANTID`)
+- How to test: `m365agents preview --local` (Agents Playground)
 - Relevant commands for their app type

--- a/teams-app-dev/commands/teams-sideload.md
+++ b/teams-app-dev/commands/teams-sideload.md
@@ -1,7 +1,7 @@
 ---
 name: teams-sideload
-description: "Package and sideload a Teams app for testing"
-argument-hint: "[--path <appPackage-dir>] [--env <environment>]"
+description: "Package and sideload a Teams app for testing — supports M365 Agents Toolkit and Agents Playground"
+argument-hint: "[--path <appPackage-dir>] [--env <environment>] [--playground]"
 allowed-tools:
   - Read
   - Write
@@ -12,77 +12,80 @@ allowed-tools:
 
 # Package and Sideload a Teams App
 
-Build the app package (ZIP) and sideload it into Teams for testing.
+Build the app package (ZIP) and sideload it into Teams for testing, or use Agents Playground for local development.
 
 ## Instructions
 
-### 1. Locate App Package Files
+### 1. Choose Testing Method
+
+- `--playground` — Use Agents Playground for local testing (no registration needed)
+- Default — Package and sideload to Teams client
+
+**Agents Playground** (recommended for local dev):
+```bash
+m365agents preview --local
+```
+
+If `--playground` is set, run the above and skip to Step 6.
+
+### 2. Locate App Package Files
 
 Find the manifest and icons:
 - `--path` specifies the appPackage directory (default: `./appPackage`)
 - Required files: `manifest.json`, `color.png`, `outline.png`
 
-Verify all three files exist. If missing, tell the user which files are needed.
+### 3. Resolve Template Variables
 
-### 2. Resolve Template Variables
-
-If the manifest contains `{{VAR}}` placeholders (Teams Toolkit style):
+If the manifest contains `{{VAR}}` placeholders:
 - Read the environment file (`env/.env.<env>` or `.env`) to get variable values
 - Replace all `{{VAR}}` with their values in a temporary copy of the manifest
-- Common variables: `APP_ID`, `BOT_ID`, `BOT_ENDPOINT`, `AZURE_CLIENT_ID`, `TAB_ENDPOINT`
+- Common variables: `APP_ID`, `BOT_ID`, `BOT_ENDPOINT`, `AZURE_CLIENT_ID`, `TAB_ENDPOINT`, `APP_TENANTID`
 
-If any variable is unresolved, warn the user and list the missing variables.
+### 4. Validate Before Packaging
 
-### 3. Validate Before Packaging
-
-Run quick validation on the resolved manifest:
+Run quick validation:
+- `manifestVersion` is `"1.25"` (warn if older)
 - `id` is a valid, non-placeholder GUID
 - `botId` (if present) is a valid, non-placeholder GUID
-- `validDomains` does not contain `localhost` (unless explicitly developing locally)
 - All referenced icon files exist
 
-### 4. Create the ZIP Package
+### 5. Create the ZIP Package
 
-**Option A: Teams Toolkit (preferred)**:
+**Option A: M365 Agents Toolkit (preferred)**:
 ```bash
-teamsapp package --manifest-path <path>/manifest.json --output-zip-path ./appPackage/build/appPackage.zip
+m365agents package --manifest-path <path>/manifest.json --output-zip-path ./appPackage/build/appPackage.zip
 ```
 
 **Option B: Manual packaging**:
 ```bash
 cd <appPackage-dir>
-# Create ZIP with manifest.json, color.png, outline.png at the root level
 zip -j ../appPackage.zip manifest.json color.png outline.png
 ```
 
-The ZIP must contain the three files at the **root level** (no subdirectories).
+### 6. Sideload to Teams
 
-### 5. Sideload to Teams
-
-**Option A: Teams Toolkit**:
+**Option A: M365 Agents Toolkit**:
 ```bash
-teamsapp preview --local    # For local development
-teamsapp preview --remote   # For deployed app
+m365agents preview --local    # For local development
+m365agents preview --remote   # For deployed app
 ```
 
 **Option B: Manual sideload**:
-1. Open Microsoft Teams (desktop or web).
-2. Go to **Apps** (left sidebar) > **Manage your apps** > **Upload an app**.
-3. Select **Upload a custom app** (or **Upload for my org** if publishing to org).
-4. Choose the ZIP file created in Step 4.
-5. Teams will show a preview of the app — click **Add** to install.
+1. Open Microsoft Teams > **Apps** > **Manage your apps** > **Upload an app**.
+2. Select **Upload a custom app**.
+3. Choose the ZIP file.
+4. Click **Add** to install.
 
-If "Upload a custom app" is not visible, the org admin must enable custom app sideloading:
-- Teams Admin Center > Teams apps > Setup policies > Global policy > Enable "Upload custom apps"
-
-### 6. Verify Installation
+### 7. Verify Installation
 
 After sideloading:
-- **Bot**: Send a message in the chat where the bot was added. Check for a response.
+- **Bot**: Send a message and check for a response.
 - **Tab**: Open the tab and verify content loads.
-- **Message extension**: Open the compose box, click the `...` menu, and find the extension.
+- **Message extension**: Open the compose box and find the extension.
+- **Meeting app**: Schedule a meeting and add the app. Check side panel and stage.
 
 If the app fails to install, check:
-- The bot endpoint is reachable (use `curl <endpoint>/api/messages`)
+- The bot endpoint is reachable
 - The manifest passes validation (`/teams-manifest --validate`)
 - Sideloading is enabled in the tenant
+- Bot is registered as **Single Tenant** with correct `APP_TENANTID`

--- a/teams-app-dev/skills/teams-app-dev/SKILL.md
+++ b/teams-app-dev/skills/teams-app-dev/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: Teams App Dev
 description: >
-  Deep expertise in custom Microsoft Teams app development — build bots with Bot Framework
-  and TeamsActivityHandler, design Adaptive Cards with schema 1.5+, create search/action/link-unfurling
-  message extensions, develop tab apps with Teams JS SDK v2 and SSO, author app manifests v1.17+,
-  and manage the full dev lifecycle with Teams Toolkit CLI. Targets professional TypeScript developers
-  building production Teams apps.
+  Deep expertise in custom Microsoft Teams app development — manifest v1.25 schema,
+  M365 Agents Toolkit CLI, Adaptive Cards 1.6, search/action/link-unfurling message extensions,
+  meeting apps (side panel, stage, content bubble), Custom Engine Agents, Agent 365 blueprints,
+  Nested App Authentication (NAA), dialog namespace (replacing task modules), single-tenant bot
+  registration, and Agents Playground for local testing. Targets professional TypeScript developers
+  building production Teams apps on the Microsoft 365 platform.
 allowed-tools:
   - Read
   - Write
@@ -15,7 +16,7 @@ allowed-tools:
   - Bash
 triggers:
   - teams app
-  - teams toolkit
+  - m365 agents toolkit
   - adaptive card
   - message extension
   - bot framework
@@ -26,6 +27,14 @@ triggers:
   - teams sso
   - link unfurling
   - task module
+  - dialog
+  - meeting app
+  - meeting extension
+  - custom engine agent
+  - agent 365
+  - agents playground
+  - nested app auth
+  - naa
 ---
 
 # Teams App Dev
@@ -41,72 +50,77 @@ Microsoft Teams apps extend Teams with custom functionality through several surf
 | Message extension | Compose box, message actions | Bot Framework search/action handlers |
 | Tab (static) | Personal app, channel tab | React/HTML + Teams JS SDK v2 |
 | Tab (configurable) | Channel/group chat tab | React/HTML + configuration page |
+| Meeting extension | Pre/in/post meeting, side panel, stage | Tabs + bots + content bubble |
+| Custom Engine Agent | Conversational AI agent | M365 Agents Toolkit + AI SDK |
+| Agent 365 | Declarative agent | Agent 365 manifest + MCP tools |
 | Connector | Channel notifications | Incoming/outgoing webhooks or O365 connectors |
-| Meeting extension | Pre/in/post meeting | Tabs + bots + content bubble |
 
 **Development stack**:
 - **Language**: TypeScript (recommended) or C#/.NET
 - **Bot runtime**: `botbuilder` + `botbuilder-teams` npm packages (Bot Framework SDK v4)
 - **Frontend**: React with `@microsoft/teams-js` SDK v2
-- **Auth**: MSAL.js + Azure AD app registration (SSO via `getAuthToken`)
-- **Tooling**: Teams Toolkit CLI (`teamsapp`) or VS Code Teams Toolkit extension
+- **Auth**: MSAL.js + Entra ID app registration (SSO via `getAuthToken`) — **single-tenant enforced**
+- **Tooling**: M365 Agents Toolkit CLI (`m365agents`) — replaces Teams Toolkit CLI
 - **Hosting**: Azure App Service, Azure Functions, or any HTTPS endpoint
+- **Local testing**: Agents Playground (no bot registration required)
 
-**Teams Toolkit vs manual setup**:
-| Aspect | Teams Toolkit | Manual |
-|--------|--------------|--------|
-| Project scaffold | `teamsapp new` generates full project | Create files from scratch |
-| Azure provisioning | `teamsapp provision` creates resources | ARM/Bicep templates or portal |
-| Manifest management | Template variables `{{BOT_ID}}` auto-resolved | Hardcoded GUIDs |
-| Local debug | `teamsapp preview --local` with dev tunnel | ngrok + manual sideload |
-| Deployment | `teamsapp deploy` to Azure | CI/CD pipeline or manual |
+**M365 Agents Toolkit vs legacy Teams Toolkit**:
+| Aspect | M365 Agents Toolkit (current) | Teams Toolkit (legacy) |
+|--------|-------------------------------|----------------------|
+| CLI package | `@microsoft/m365agentstoolkit-cli` | `@microsoft/teamsapp-cli` |
+| CLI command | `m365agents` | `teamsapp` |
+| Config file | `m365agents.yml` | `teamsapp.yml` |
+| Manifest schema | v1.25 | v1.17 |
+| Bot auth | Single-tenant with `APP_TENANTID` | Multi-tenant |
+| Local testing | Agents Playground (no registration) | Dev tunnel + sideload |
+| Agent support | Custom Engine Agents, Agent 365 | N/A |
 
-## 2. Teams Toolkit CLI
+## 2. M365 Agents Toolkit CLI
 
-Teams Toolkit CLI (`teamsapp`) manages the full app lifecycle.
+M365 Agents Toolkit CLI (`m365agents`) manages the full app lifecycle. It replaces the legacy `teamsapp` CLI.
 
 **Install**:
 ```bash
-npm install -g @microsoft/teamsapp-cli
+npm install -g @microsoft/m365agentstoolkit-cli
 ```
 
 **Core commands**:
 | Command | Description |
 |---------|-------------|
-| `teamsapp new` | Scaffold a new Teams app project |
-| `teamsapp provision` | Create Azure resources defined in `teamsapp.yml` |
-| `teamsapp deploy` | Deploy code to provisioned Azure resources |
-| `teamsapp preview --local` | Start local debug with dev tunnel and sideload |
-| `teamsapp preview --remote` | Preview deployed app in Teams |
-| `teamsapp validate` | Validate manifest against schema |
-| `teamsapp package` | Build the app package (ZIP with manifest + icons) |
-| `teamsapp publish` | Publish to org app catalog |
-| `teamsapp env list` | List configured environments |
-| `teamsapp env add <name>` | Add a new environment |
+| `m365agents new` | Scaffold a new Teams app or agent project |
+| `m365agents provision` | Create Azure resources defined in `m365agents.yml` |
+| `m365agents deploy` | Deploy code to provisioned Azure resources |
+| `m365agents preview --local` | Start local debug with Agents Playground |
+| `m365agents preview --remote` | Preview deployed app in Teams |
+| `m365agents validate` | Validate manifest against v1.25 schema |
+| `m365agents package` | Build the app package (ZIP with manifest + icons) |
+| `m365agents publish` | Publish to org app catalog |
+| `m365agents env list` | List configured environments |
+| `m365agents env add <name>` | Add a new environment |
 
-**Project structure** (generated by `teamsapp new`):
+**Project structure** (generated by `m365agents new`):
 ```
 my-teams-app/
-├── teamsapp.yml             # Lifecycle configuration
-├── teamsapp.local.yml       # Local debug overrides
+├── m365agents.yml            # Lifecycle configuration (replaces teamsapp.yml)
+├── m365agents.local.yml      # Local debug overrides
 ├── env/
-│   ├── .env.dev             # Dev environment variables
-│   └── .env.local           # Local debug variables
+│   ├── .env.dev              # Dev environment variables
+│   └── .env.local            # Local debug variables
 ├── appPackage/
-│   ├── manifest.json         # App manifest (with {{VAR}} placeholders)
-│   ├── color.png             # 192x192 color icon
-│   └── outline.png           # 32x32 outline icon
+│   ├── manifest.json          # App manifest v1.25 (with {{VAR}} placeholders)
+│   ├── color.png              # 192x192 color icon
+│   └── outline.png            # 32x32 outline icon
 ├── src/
-│   ├── index.ts              # Entry point (bot adapter / Express server)
-│   └── teamsBot.ts           # TeamsActivityHandler implementation
+│   ├── index.ts               # Entry point (bot adapter / Express server)
+│   └── teamsBot.ts            # TeamsActivityHandler implementation
 ├── infra/
-│   └── azure.bicep           # Azure resource definitions
+│   └── azure.bicep            # Azure resource definitions
 └── package.json
 ```
 
-**`teamsapp.yml` lifecycle hooks**:
+**`m365agents.yml` lifecycle hooks**:
 ```yaml
-version: v1.4
+version: v1.6
 provision:
   - uses: teamsApp/create
     with:
@@ -117,6 +131,7 @@ provision:
   - uses: botAadApp/create
     with:
       name: my-teams-app-bot-${{TEAMSFX_ENV}}
+      appTenantId: ${{APP_TENANTID}}
     writeToEnvironmentFile:
       botId: BOT_ID
       botPassword: SECRET_BOT_PASSWORD
@@ -126,6 +141,7 @@ provision:
       botId: ${{BOT_ID}}
       name: my-teams-app-bot
       messagingEndpoint: ${{BOT_ENDPOINT}}/api/messages
+      appTenantId: ${{APP_TENANTID}}
 
   - uses: teamsApp/validateManifest
     with:
@@ -150,9 +166,27 @@ deploy:
       args: run build
 ```
 
+### Agents Playground
+
+Agents Playground allows local testing of bots and agents without Azure Bot registration or Dev Tunnels.
+
+```bash
+# Start with Agents Playground (no registration needed)
+m365agents preview --local
+
+# The playground opens a browser-based chat interface at http://localhost:56150
+# It simulates the Teams client environment locally
+```
+
+Key benefits:
+- No Azure Bot Service registration required for local dev
+- No Dev Tunnel or ngrok setup needed
+- Simulates Teams channel data, conversation references, and invoke activities
+- Supports Adaptive Card rendering and action testing
+
 ## 3. Adaptive Card Schema
 
-Adaptive Cards are platform-agnostic UI snippets rendered natively in Teams. Teams supports **schema version 1.5** (Designer preview supports 1.6).
+Adaptive Cards are platform-agnostic UI snippets rendered natively in Teams. Teams supports **schema version 1.6** on desktop/web and **1.5** on mobile.
 
 **Card structure**:
 ```json
@@ -233,7 +267,6 @@ async onAdaptiveCardInvoke(
   switch (verb) {
     case "approveRequest":
       await this.processApproval(data.requestId);
-      // Return updated card
       return {
         statusCode: 200,
         type: "application/vnd.microsoft.card.adaptive",
@@ -378,7 +411,7 @@ async handleTeamsMessagingExtensionQuery(
 
 ### Action-Based Message Extension
 
-Users fill out a form (task module) triggered from the compose box or a message context menu.
+Users fill out a form (dialog) triggered from the compose box or a message context menu.
 
 **Manifest fragment**:
 ```json
@@ -401,13 +434,12 @@ Users fill out a form (task module) triggered from the compose box or a message 
 }
 ```
 
-**Fetch task handler** (returns the form):
+**Fetch task handler** (returns the form via `dialog.url.open()` pattern):
 ```typescript
 async handleTeamsMessagingExtensionFetchTask(
   context: TurnContext,
   action: MessagingExtensionAction
 ): Promise<MessagingExtensionActionResponse> {
-  // If triggered from a message, pre-populate with message text
   const messageText = action.messagePayload?.body?.content || "";
 
   return {
@@ -553,12 +585,12 @@ Teams bots extend the Bot Framework `TeamsActivityHandler`, which provides Teams
 | `onTeamsTeamArchived` | Team archived | Status update |
 | `onTeamsTeamUnarchived` | Team unarchived | Re-enable features |
 | `handleTeamsMessagingExtensionQuery` | Search message extension | Return search results |
-| `handleTeamsMessagingExtensionFetchTask` | Action extension form | Return task module card |
+| `handleTeamsMessagingExtensionFetchTask` | Action extension form | Return dialog card |
 | `handleTeamsMessagingExtensionSubmitAction` | Action extension submit | Process form data |
 | `handleTeamsAppBasedLinkQuery` | Link unfurling | Return preview card |
 | `onAdaptiveCardInvoke` | `Action.Execute` on card | Process universal action |
-| `handleTeamsTaskModuleFetch` | Task module requested | Return task module content |
-| `handleTeamsTaskModuleSubmit` | Task module submitted | Process task module data |
+| `handleTeamsTaskModuleFetch` | Dialog requested (legacy: task/fetch) | Return dialog content |
+| `handleTeamsTaskModuleSubmit` | Dialog submitted (legacy: task/submit) | Process dialog data |
 | `onInstallationUpdate` | App installed/uninstalled | Setup or teardown per-user state |
 
 ### Bot Scaffold
@@ -609,7 +641,7 @@ export class TeamsBot extends TeamsActivityHandler {
 | `context.activity.from` | Sender info (`id`, `name`, `aadObjectId`) |
 | `context.activity.conversation` | Conversation info (`id`, `tenantId`, `conversationType`) |
 | `context.activity.channelData` | Teams-specific data (`team`, `channel`, `tenant`) |
-| `context.activity.value` | Data from card actions or task modules |
+| `context.activity.value` | Data from card actions or dialogs |
 
 ### Proactive Messaging
 
@@ -690,7 +722,380 @@ const orderDialog = new WaterfallDialog(ORDER_DIALOG, [
 ]);
 ```
 
-## 6. Tab Apps
+## 6. Meeting Apps
+
+Meeting apps extend the Teams meeting experience with pre-meeting, in-meeting, and post-meeting surfaces.
+
+### Meeting App Surfaces
+
+| Surface | When Available | Manifest Context | Technology |
+|---------|---------------|-----------------|------------|
+| Pre-meeting tab | Before meeting starts | `meetingDetailsTab` | Configurable tab |
+| Side panel | During meeting | `meetingSidePanel` | Configurable tab |
+| Meeting stage | During meeting (shared) | `meetingStage` | Configurable tab + `shareAppContentToStage` |
+| Content bubble | During meeting | N/A | Bot notification with `targetedMeetingNotification` |
+| Post-meeting tab | After meeting ends | `meetingDetailsTab` | Configurable tab |
+
+### Meeting App Manifest (v1.25)
+
+```json
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.25/MicrosoftTeams.schema.json",
+  "manifestVersion": "1.25",
+  "configurableTabs": [
+    {
+      "configurationUrl": "https://{{TAB_DOMAIN}}/config",
+      "canUpdateConfiguration": true,
+      "scopes": ["groupChat"],
+      "context": [
+        "meetingChatTab",
+        "meetingDetailsTab",
+        "meetingSidePanel",
+        "meetingStage"
+      ],
+      "supportsChannelFeatures": true
+    }
+  ],
+  "authorization": {
+    "permissions": {
+      "resourceSpecific": [
+        { "name": "OnlineMeeting.ReadBasic.Chat", "type": "Delegated" },
+        { "name": "OnlineMeetingParticipant.Read.Chat", "type": "Delegated" },
+        { "name": "MeetingStage.Write.Chat", "type": "Delegated" }
+      ]
+    }
+  }
+}
+```
+
+### Share to Meeting Stage
+
+```typescript
+import { meeting, app } from "@microsoft/teams-js";
+
+// From side panel, share content to the meeting stage
+async function shareToStage() {
+  await app.initialize();
+
+  meeting.shareAppContentToStage(
+    (err, result) => {
+      if (err) {
+        console.error("Failed to share to stage:", err);
+        return;
+      }
+      console.log("Shared to stage successfully");
+    },
+    `${window.location.origin}/stage?meetingId=${meetingId}`
+  );
+}
+```
+
+### Meeting Side Panel
+
+```typescript
+import { app, meeting } from "@microsoft/teams-js";
+
+async function initSidePanel() {
+  await app.initialize();
+  const context = await app.getContext();
+
+  if (context.page.frameContext === "sidePanel") {
+    // Side panel specific logic
+    const meetingId = context.meeting?.id;
+
+    // Get meeting details
+    meeting.getMeetingDetails((err, details) => {
+      if (details) {
+        console.log("Organizer:", details.organizer?.id);
+        console.log("Scheduled start:", details.details?.scheduledStartTime);
+      }
+    });
+  }
+}
+```
+
+### Content Bubble (In-Meeting Notification)
+
+Bots can send targeted meeting notifications that appear as content bubbles during a meeting.
+
+```typescript
+// Bot sends a targeted meeting notification
+async function sendContentBubble(context: TurnContext, meetingId: string) {
+  const card = CardFactory.adaptiveCard({
+    type: "AdaptiveCard",
+    version: "1.5",
+    body: [
+      { type: "TextBlock", text: "Action Required", weight: "Bolder" },
+      { type: "TextBlock", text: "Please vote on the current agenda item", wrap: true },
+    ],
+    actions: [
+      { type: "Action.Execute", title: "Vote Yes", verb: "vote", data: { vote: "yes" } },
+      { type: "Action.Execute", title: "Vote No", verb: "vote", data: { vote: "no" } },
+    ],
+  });
+
+  // Targeted notification surfaces as a content bubble during the meeting
+  await context.sendActivity({
+    type: "message",
+    attachments: [card],
+    channelData: {
+      notification: {
+        alertInMeeting: true,
+        externalResourceUrl: `https://${process.env.TAB_DOMAIN}/stage?action=vote`,
+      },
+    },
+  });
+}
+```
+
+### Meeting Message Extensions
+
+Message extensions work within meeting chats. When a meeting is active, extensions can:
+- Search and share content relevant to the meeting agenda
+- Create action items from the meeting chat context
+- Unfurl links shared during the meeting with rich previews
+
+**Meeting-aware search extension**:
+```typescript
+async handleTeamsMessagingExtensionQuery(
+  context: TurnContext,
+  query: MessagingExtensionQuery
+): Promise<MessagingExtensionResponse> {
+  const searchText = query.parameters?.[0]?.value || "";
+
+  // Detect meeting context from channel data
+  const meetingId = context.activity.channelData?.meeting?.id;
+  const isMeetingChat = !!meetingId;
+
+  let results;
+  if (isMeetingChat) {
+    // Fetch meeting-specific agenda items or related content
+    results = await this.searchMeetingAgendaItems(meetingId, searchText);
+  } else {
+    results = await this.searchAllItems(searchText);
+  }
+
+  const attachments = results.map((item) => ({
+    contentType: "application/vnd.microsoft.card.adaptive",
+    content: {
+      type: "AdaptiveCard",
+      version: "1.5",
+      body: [
+        { type: "TextBlock", text: item.title, weight: "Bolder", size: "Medium" },
+        { type: "TextBlock", text: item.description, wrap: true },
+        ...(isMeetingChat ? [
+          { type: "TextBlock", text: `📋 Agenda: ${item.agendaItem}`, isSubtle: true }
+        ] : []),
+      ],
+    },
+    preview: CardFactory.heroCard(item.title, item.description),
+  }));
+
+  return {
+    composeExtension: {
+      type: "result",
+      attachmentLayout: "list",
+      attachments,
+    },
+  };
+}
+```
+
+**Meeting action extension — create action item from meeting chat**:
+```typescript
+async handleTeamsMessagingExtensionFetchTask(
+  context: TurnContext,
+  action: MessagingExtensionAction
+): Promise<MessagingExtensionActionResponse> {
+  const meetingId = context.activity.channelData?.meeting?.id;
+  const messageText = action.messagePayload?.body?.content || "";
+
+  return {
+    task: {
+      type: "continue",
+      value: {
+        title: "Create Meeting Action Item",
+        width: "medium",
+        height: "medium",
+        card: CardFactory.adaptiveCard({
+          type: "AdaptiveCard",
+          version: "1.5",
+          body: [
+            { type: "TextBlock", text: "Create Action Item", size: "Large", weight: "Bolder" },
+            { type: "Input.Text", id: "title", label: "Action Item", value: messageText, isRequired: true },
+            { type: "Input.Text", id: "assignee", label: "Assign To", placeholder: "user@contoso.com" },
+            { type: "Input.Date", id: "dueDate", label: "Due Date" },
+            {
+              type: "Input.ChoiceSet",
+              id: "priority",
+              label: "Priority",
+              choices: [
+                { title: "High", value: "high" },
+                { title: "Medium", value: "medium" },
+                { title: "Low", value: "low" },
+              ],
+              value: "medium",
+            },
+          ],
+          actions: [{ type: "Action.Submit", title: "Create", data: { meetingId } }],
+        }),
+      },
+    },
+  };
+}
+
+async handleTeamsMessagingExtensionSubmitAction(
+  context: TurnContext,
+  action: MessagingExtensionAction
+): Promise<MessagingExtensionActionResponse> {
+  const { title, assignee, dueDate, priority, meetingId } = action.data;
+  const actionItem = await this.createActionItem({ title, assignee, dueDate, priority, meetingId });
+
+  return {
+    composeExtension: {
+      type: "result",
+      attachmentLayout: "list",
+      attachments: [
+        CardFactory.adaptiveCard({
+          type: "AdaptiveCard",
+          version: "1.5",
+          body: [
+            { type: "TextBlock", text: `Action Item Created`, weight: "Bolder" },
+            { type: "FactSet", facts: [
+              { title: "Title", value: title },
+              { title: "Assigned To", value: assignee || "Unassigned" },
+              { title: "Due", value: dueDate || "No date" },
+              { title: "Priority", value: priority },
+              { title: "Meeting", value: meetingId ? "Linked" : "None" },
+            ]},
+          ],
+        }),
+      ],
+    },
+  };
+}
+```
+
+## 7. Dialog Namespace (Replaces Task Modules)
+
+The `dialog` namespace replaces the deprecated `tasks` namespace. Use `dialog.url.open()` and `dialog.adaptiveCard.open()` instead of `tasks.startTask()`.
+
+### Opening a Dialog from a Tab
+
+```typescript
+import { dialog, app } from "@microsoft/teams-js";
+
+// Open a dialog with an Adaptive Card
+async function openAdaptiveCardDialog() {
+  await app.initialize();
+
+  dialog.adaptiveCard.open({
+    card: JSON.stringify({
+      type: "AdaptiveCard",
+      version: "1.5",
+      body: [
+        { type: "TextBlock", text: "Submit Feedback", size: "Large", weight: "Bolder" },
+        { type: "Input.Text", id: "feedback", label: "Your feedback", isMultiline: true, isRequired: true },
+        { type: "Input.ChoiceSet", id: "rating", label: "Rating", choices: [
+          { title: "Excellent", value: "5" },
+          { title: "Good", value: "4" },
+          { title: "Average", value: "3" },
+          { title: "Poor", value: "2" },
+        ]},
+      ],
+      actions: [{ type: "Action.Submit", title: "Submit" }],
+    }),
+    title: "Feedback",
+    size: { width: "medium", height: "medium" },
+  }, (result) => {
+    if (result.err) {
+      console.error("Dialog error:", result.err);
+      return;
+    }
+    const data = JSON.parse(result.result as string);
+    console.log("Feedback:", data.feedback, "Rating:", data.rating);
+  });
+}
+
+// Open a dialog with a URL (iframe)
+async function openUrlDialog() {
+  await app.initialize();
+
+  dialog.url.open({
+    url: `${window.location.origin}/dialog/form`,
+    title: "Create Item",
+    size: { width: "large", height: "large" },
+    fallbackUrl: `${window.location.origin}/dialog/form`,
+  }, (result) => {
+    if (result.err) {
+      console.error("Dialog error:", result.err);
+      return;
+    }
+    console.log("Dialog result:", result.result);
+  });
+}
+```
+
+### Submitting from Inside a Dialog
+
+```typescript
+import { dialog, app } from "@microsoft/teams-js";
+
+// Call from within the dialog iframe to close and return data
+async function submitDialog() {
+  await app.initialize();
+
+  const formData = {
+    title: document.getElementById("title")?.value,
+    description: document.getElementById("description")?.value,
+  };
+
+  dialog.url.submit(JSON.stringify(formData));
+}
+```
+
+### Bot-Side Dialog Handlers
+
+```typescript
+// These handlers respond to task/fetch and task/submit invokes
+// The method names are legacy but the client uses the dialog namespace
+
+protected async handleTeamsTaskModuleFetch(
+  context: TurnContext,
+  taskModuleRequest: { data: Record<string, string> }
+) {
+  return {
+    task: {
+      type: "continue",
+      value: {
+        title: "Create Item",
+        height: 450,
+        width: 500,
+        card: CardFactory.adaptiveCard({
+          type: "AdaptiveCard",
+          version: "1.5",
+          body: [
+            { type: "Input.Text", id: "title", label: "Title", isRequired: true },
+            { type: "Input.Text", id: "notes", label: "Notes", isMultiline: true },
+          ],
+          actions: [{ type: "Action.Submit", title: "Create" }],
+        }),
+      },
+    },
+  };
+}
+
+protected async handleTeamsTaskModuleSubmit(
+  context: TurnContext,
+  taskModuleRequest: { data: Record<string, string> }
+) {
+  const { title, notes } = taskModuleRequest.data;
+  await this.createItem(title, notes);
+  return { task: { type: "message", value: `Created: ${title}` } };
+}
+```
+
+## 8. Tab Apps
 
 Tabs embed web content as personal apps or channel tabs inside Teams.
 
@@ -720,26 +1125,46 @@ async function initializeApp() {
   console.log("User ID:", context.user?.id);
   console.log("Team ID:", context.team?.internalId);
   console.log("Channel ID:", context.channel?.id);
+  console.log("Host:", context.app.host.name); // "Teams" | "Outlook" | "Office"
 }
 ```
 
-**Key `app.getContext()` properties**:
-| Property | Description |
-|----------|-------------|
-| `context.app.theme` | `"default"`, `"dark"`, or `"contrast"` |
-| `context.app.locale` | User's locale (e.g., `"en-us"`) |
-| `context.user.id` | Azure AD object ID |
-| `context.user.userPrincipalName` | UPN (email) |
-| `context.team.internalId` | Team ID (in channel tabs) |
-| `context.channel.id` | Channel ID (in channel tabs) |
-| `context.page.id` | Entity ID configured for the tab |
-| `context.page.subPageId` | Deep link sub-entity ID |
+### SSO Authentication Pattern — Nested App Authentication (NAA)
 
-### SSO Authentication Pattern
+Manifest v1.25 introduces **Nested App Authentication (NAA)** for pop-up-free iframe authentication.
 
-Teams tab SSO provides a silent token for the signed-in user without a popup.
+**Manifest v1.25 `nestedAppAuthInfo`**:
+```json
+{
+  "nestedAppAuthInfo": {
+    "oidcScopes": ["openid", "profile", "email", "offline_access"],
+    "accessTokenAcceptedVersion": 2
+  },
+  "webApplicationInfo": {
+    "id": "{{AZURE_CLIENT_ID}}",
+    "resource": "api://{{TAB_DOMAIN}}/{{AZURE_CLIENT_ID}}"
+  }
+}
+```
 
-**Client-side (tab)**:
+**Client-side with NAA** (no popup required):
+```typescript
+import { authentication, app } from "@microsoft/teams-js";
+
+async function getTokenWithNAA(): Promise<string> {
+  await app.initialize();
+
+  // NAA enables silent token acquisition without pop-up
+  // The token is acquired through the parent app (Teams) acting as a broker
+  const token = await authentication.getAuthToken({
+    silent: true,
+  });
+
+  return token;
+}
+```
+
+**Traditional SSO (fallback)**:
 ```typescript
 import { authentication } from "@microsoft/teams-js";
 
@@ -759,7 +1184,8 @@ const msalClient = new ConfidentialClientApplication({
   auth: {
     clientId: process.env.AZURE_CLIENT_ID!,
     clientSecret: process.env.AZURE_CLIENT_SECRET!,
-    authority: `https://login.microsoftonline.com/${process.env.AZURE_TENANT_ID}`,
+    // Single-tenant authority — APP_TENANTID required in v1.25
+    authority: `https://login.microsoftonline.com/${process.env.APP_TENANTID}`,
   },
 });
 
@@ -810,16 +1236,35 @@ export function Tab() {
 }
 ```
 
-## 7. Teams App Manifest v1.17+
+## 9. Teams App Manifest v1.25
 
-The manifest (`manifest.json`) is the app's contract with Teams. It declares capabilities, permissions, and entry points.
+The manifest (`manifest.json`) is the app's contract with Teams. Manifest v1.25 is the current schema version.
+
+### What Changed from v1.17 to v1.25
+
+| Feature | v1.17 | v1.25 |
+|---------|-------|-------|
+| Schema URL | `v1.17/MicrosoftTeams.schema.json` | `v1.25/MicrosoftTeams.schema.json` |
+| `manifestVersion` | `"1.17"` | `"1.25"` |
+| Bot tenancy | Multi-tenant | **Single-tenant** with `APP_TENANTID` |
+| `supportsChannelFeatures` | N/A | New boolean on configurable tabs |
+| `nestedAppAuthInfo` | N/A | NAA for pop-up-free SSO |
+| `backgroundLoadConfiguration` | N/A | Background tab preloading |
+| `agenticUserTemplates` | N/A | Custom Engine Agent prompt templates |
+| Tooling | `teamsapp` CLI | `m365agents` CLI |
+| Config file | `teamsapp.yml` | `m365agents.yml` |
+
+### Known v1.25 Bugs
+
+1. **Regex validation**: The Dev Portal schema validator may reject valid regex patterns in `Input.Text.regex`. Workaround: validate locally with `m365agents validate`.
+2. **Dev Portal save issue**: Editing manifests directly in the Teams Developer Portal may silently drop `nestedAppAuthInfo` and `agenticUserTemplates` fields. Workaround: always author manifests in your codebase and use `m365agents package`.
 
 ### Required Fields
 
 ```json
 {
-  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.17/MicrosoftTeams.schema.json",
-  "manifestVersion": "1.17",
+  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.25/MicrosoftTeams.schema.json",
+  "manifestVersion": "1.25",
   "version": "1.0.0",
   "id": "{{APP_ID}}",
   "developer": {
@@ -845,7 +1290,9 @@ The manifest (`manifest.json`) is the app's contract with Teams. It declares cap
 }
 ```
 
-### Bot Registration
+### Bot Registration (Single-Tenant)
+
+All bot registrations in v1.25 enforce single-tenant with `APP_TENANTID`.
 
 ```json
 {
@@ -869,6 +1316,23 @@ The manifest (`manifest.json`) is the app's contract with Teams. It declares cap
 }
 ```
 
+**Bicep for single-tenant bot**:
+```bicep
+resource botService 'Microsoft.BotService/botServices@2022-09-15' = {
+  name: botServiceName
+  location: 'global'
+  sku: { name: 'F0' }
+  kind: 'azurebot'
+  properties: {
+    displayName: botServiceName
+    endpoint: botEndpoint
+    msaAppId: botAadAppClientId
+    msaAppType: 'SingleTenant'
+    msaAppTenantId: appTenantId   // Required for v1.25
+  }
+}
+```
+
 ### Static Tabs
 
 ```json
@@ -885,7 +1349,7 @@ The manifest (`manifest.json`) is the app's contract with Teams. It declares cap
 }
 ```
 
-### Configurable Tabs
+### Configurable Tabs with supportsChannelFeatures
 
 ```json
 {
@@ -894,7 +1358,51 @@ The manifest (`manifest.json`) is the app's contract with Teams. It declares cap
       "configurationUrl": "https://contoso.com/tabs/config",
       "canUpdateConfiguration": true,
       "scopes": ["team", "groupChat"],
-      "context": ["channelTab", "privateChatTab"]
+      "context": ["channelTab", "privateChatTab", "meetingSidePanel", "meetingStage"],
+      "supportsChannelFeatures": true
+    }
+  ]
+}
+```
+
+### Nested App Authentication (NAA)
+
+```json
+{
+  "nestedAppAuthInfo": {
+    "oidcScopes": ["openid", "profile", "email", "offline_access"],
+    "accessTokenAcceptedVersion": 2
+  }
+}
+```
+
+### Background Load Configuration
+
+```json
+{
+  "backgroundLoadConfiguration": {
+    "enabled": true,
+    "preloadOnAppInstall": true
+  }
+}
+```
+
+### Agentic User Templates
+
+```json
+{
+  "agenticUserTemplates": [
+    {
+      "id": "summarize",
+      "title": "Summarize conversation",
+      "description": "Generate a summary of the current conversation",
+      "prompt": "Summarize the key points discussed in this conversation."
+    },
+    {
+      "id": "actionItems",
+      "title": "Extract action items",
+      "description": "List all action items from the conversation",
+      "prompt": "Extract and list all action items from this conversation, including assignees and deadlines."
     }
   ]
 }
@@ -927,12 +1435,12 @@ The manifest (`manifest.json`) is the app's contract with Teams. It declares cap
 }
 ```
 
-### Complete Manifest Example
+### Complete Manifest v1.25 Example
 
 ```json
 {
-  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.17/MicrosoftTeams.schema.json",
-  "manifestVersion": "1.17",
+  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.25/MicrosoftTeams.schema.json",
+  "manifestVersion": "1.25",
   "version": "1.0.0",
   "id": "{{APP_ID}}",
   "developer": {
@@ -941,10 +1449,10 @@ The manifest (`manifest.json`) is the app's contract with Teams. It declares cap
     "privacyUrl": "https://contoso.com/privacy",
     "termsOfUseUrl": "https://contoso.com/terms"
   },
-  "name": { "short": "Contoso Helper", "full": "Contoso Helper — Bot and Tabs" },
+  "name": { "short": "Contoso Helper", "full": "Contoso Helper — Bot, Tabs, and Meeting App" },
   "description": {
     "short": "Search products and manage tickets",
-    "full": "A Teams app with a conversational bot, product search message extension, and a dashboard tab."
+    "full": "A Teams app with a conversational bot, product search message extension, dashboard tab, and meeting side panel with stage sharing."
   },
   "icons": { "color": "color.png", "outline": "outline.png" },
   "accentColor": "#4F6BED",
@@ -976,6 +1484,20 @@ The manifest (`manifest.json`) is the app's contract with Teams. It declares cap
           "parameters": [
             { "name": "query", "title": "Search", "description": "Product name or SKU" }
           ]
+        },
+        {
+          "id": "createActionItem",
+          "type": "action",
+          "title": "Create Action Item",
+          "description": "Create an action item from this message",
+          "context": ["message", "compose"],
+          "fetchTask": true
+        }
+      ],
+      "messageHandlers": [
+        {
+          "type": "link",
+          "value": { "domains": ["contoso.com"] }
         }
       ]
     }
@@ -988,15 +1510,231 @@ The manifest (`manifest.json`) is the app's contract with Teams. It declares cap
       "scopes": ["personal"]
     }
   ],
+  "configurableTabs": [
+    {
+      "configurationUrl": "https://contoso.com/tabs/config",
+      "canUpdateConfiguration": true,
+      "scopes": ["team", "groupChat"],
+      "context": ["channelTab", "meetingSidePanel", "meetingStage"],
+      "supportsChannelFeatures": true
+    }
+  ],
   "validDomains": ["contoso.com"],
   "webApplicationInfo": {
     "id": "{{AZURE_CLIENT_ID}}",
     "resource": "api://contoso.com/{{AZURE_CLIENT_ID}}"
+  },
+  "nestedAppAuthInfo": {
+    "oidcScopes": ["openid", "profile", "email", "offline_access"],
+    "accessTokenAcceptedVersion": 2
+  },
+  "backgroundLoadConfiguration": {
+    "enabled": true,
+    "preloadOnAppInstall": true
+  },
+  "authorization": {
+    "permissions": {
+      "resourceSpecific": [
+        { "name": "OnlineMeeting.ReadBasic.Chat", "type": "Delegated" },
+        { "name": "MeetingStage.Write.Chat", "type": "Delegated" },
+        { "name": "ChannelMessage.Read.Group", "type": "Application" }
+      ]
+    }
   }
 }
 ```
 
-## 8. Graph API for App Management
+## 10. Custom Engine Agents
+
+Custom Engine Agents are conversational AI agents built with the M365 Agents Toolkit. They combine Bot Framework with AI SDK capabilities.
+
+### Scaffold a Custom Engine Agent
+
+```bash
+m365agents new --capability custom-engine-agent --app-name MyAgent
+```
+
+### Agent Structure
+
+```typescript
+import { TeamsActivityHandler, TurnContext, MessageFactory } from "botbuilder";
+
+export class CustomEngineAgent extends TeamsActivityHandler {
+  private aiClient: AIClient;
+
+  constructor(aiClient: AIClient) {
+    super();
+    this.aiClient = aiClient;
+
+    this.onMessage(async (context: TurnContext, next) => {
+      const userMessage = context.activity.text?.trim() || "";
+
+      // Process through AI pipeline
+      const response = await this.aiClient.chat({
+        messages: [
+          { role: "system", content: "You are a helpful assistant for Contoso employees." },
+          { role: "user", content: userMessage },
+        ],
+      });
+
+      await context.sendActivity(MessageFactory.text(response.content));
+      await next();
+    });
+  }
+}
+```
+
+### Agent with Tools (Function Calling)
+
+```typescript
+export class ToolCallingAgent extends TeamsActivityHandler {
+  private tools = [
+    {
+      name: "searchProducts",
+      description: "Search the product catalog",
+      parameters: {
+        type: "object",
+        properties: {
+          query: { type: "string", description: "Search query" },
+        },
+        required: ["query"],
+      },
+    },
+    {
+      name: "getOrderStatus",
+      description: "Get the status of an order",
+      parameters: {
+        type: "object",
+        properties: {
+          orderId: { type: "string", description: "Order ID" },
+        },
+        required: ["orderId"],
+      },
+    },
+  ];
+
+  private async executeTool(name: string, args: Record<string, string>): Promise<string> {
+    switch (name) {
+      case "searchProducts":
+        return JSON.stringify(await this.productService.search(args.query));
+      case "getOrderStatus":
+        return JSON.stringify(await this.orderService.getStatus(args.orderId));
+      default:
+        return JSON.stringify({ error: "Unknown tool" });
+    }
+  }
+}
+```
+
+## 11. Agent 365
+
+Agent 365 is a declarative agent framework for building agents with manifest-driven configuration and MCP tool integration.
+
+### Agent 365 Manifest
+
+```json
+{
+  "agentManifest": {
+    "id": "contoso-support-agent",
+    "name": "Contoso Support Agent",
+    "description": "Handles customer support inquiries using company knowledge base",
+    "instructions": "You are a support agent for Contoso. Help users with product questions, order status, and troubleshooting. Always be polite and professional.",
+    "capabilities": {
+      "tools": [
+        {
+          "type": "mcp",
+          "server": "contoso-api",
+          "tools": ["searchKnowledgeBase", "getOrderStatus", "createTicket"]
+        }
+      ],
+      "knowledge": {
+        "sources": [
+          {
+            "type": "sharepoint",
+            "siteUrl": "https://contoso.sharepoint.com/sites/knowledge"
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+### Agent 365 Identity Configuration
+
+```json
+{
+  "webApplicationInfo": {
+    "id": "{{AZURE_CLIENT_ID}}",
+    "resource": "api://{{TAB_DOMAIN}}/{{AZURE_CLIENT_ID}}"
+  },
+  "nestedAppAuthInfo": {
+    "oidcScopes": ["openid", "profile", "email"],
+    "accessTokenAcceptedVersion": 2
+  }
+}
+```
+
+## 12. Authentication Patterns — Single-Tenant
+
+All v1.25 bot registrations enforce single-tenant authentication.
+
+### Environment Configuration
+
+```
+BOT_ID=<microsoft-app-id>
+BOT_PASSWORD=<client-secret>
+BOT_ENDPOINT=https://<your-domain>
+APP_TENANTID=<your-tenant-id>
+AZURE_CLIENT_ID=<your-client-id>
+AZURE_CLIENT_SECRET=<your-client-secret>
+```
+
+### Bot Adapter (Single-Tenant)
+
+```typescript
+import { CloudAdapter, ConfigurationServiceClientCredentialFactory, ConfigurationBotFrameworkAuthentication } from "botbuilder";
+
+const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
+  MicrosoftAppId: process.env.BOT_ID!,
+  MicrosoftAppPassword: process.env.BOT_PASSWORD!,
+  MicrosoftAppType: "SingleTenant",
+  MicrosoftAppTenantId: process.env.APP_TENANTID!,
+});
+
+const botFrameworkAuthentication = new ConfigurationBotFrameworkAuthentication(
+  {},
+  credentialsFactory
+);
+
+const adapter = new CloudAdapter(botFrameworkAuthentication);
+```
+
+### Bot Authentication (OAuthPrompt)
+
+Bot Framework's `OAuthPrompt` handles sign-in flows for bots, including Teams SSO.
+
+```typescript
+import { OAuthPrompt, OAuthPromptSettings } from "botbuilder-dialogs";
+
+const oauthSettings: OAuthPromptSettings = {
+  connectionName: process.env.OAUTH_CONNECTION_NAME!,
+  text: "Please sign in to continue.",
+  title: "Sign In",
+  timeout: 300000,
+};
+
+const oauthPrompt = new OAuthPrompt("oauthPrompt", oauthSettings);
+```
+
+**Azure Bot OAuth connection setup** (single-tenant):
+1. Azure Portal > Bot resource > Configuration > OAuth Connection Settings.
+2. Add a new connection with service provider `Azure Active Directory v2`.
+3. Set `Client ID`, `Client Secret`, **`Tenant ID`** (required for single-tenant).
+4. Scopes: `openid profile User.Read` (add more as needed).
+5. Use the connection name in `OAuthPromptSettings.connectionName`.
+
+## 13. Graph API for App Management
 
 Manage Teams apps in the organization catalog and per-team/user installations via Microsoft Graph.
 
@@ -1017,84 +1755,7 @@ Manage Teams apps in the organization catalog and per-team/user installations vi
 | Install app in team | `POST` | `/teams/{team-id}/installedApps` | `TeamsAppInstallation.ReadWriteForTeam` |
 | Remove from team | `DELETE` | `/teams/{team-id}/installedApps/{id}` | `TeamsAppInstallation.ReadWriteForTeam` |
 
-**Install app in team**:
-```
-POST https://graph.microsoft.com/v1.0/teams/{team-id}/installedApps
-Content-Type: application/json
-
-{
-  "teamsApp@odata.bind": "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps/{app-id}"
-}
-```
-
-### Per-User Installation
-
-| Operation | Method | Endpoint | Permission |
-|-----------|--------|----------|------------|
-| List user apps | `GET` | `/users/{user-id}/teamwork/installedApps?$expand=teamsAppDefinition` | `TeamsAppInstallation.ReadForUser` |
-| Install for user | `POST` | `/users/{user-id}/teamwork/installedApps` | `TeamsAppInstallation.ReadWriteForUser` |
-| Remove for user | `DELETE` | `/users/{user-id}/teamwork/installedApps/{id}` | `TeamsAppInstallation.ReadWriteForUser` |
-
-## 9. Authentication Patterns
-
-### Bot Authentication (OAuthPrompt)
-
-Bot Framework's `OAuthPrompt` handles sign-in flows for bots, including Teams SSO.
-
-```typescript
-import { OAuthPrompt, OAuthPromptSettings } from "botbuilder-dialogs";
-
-const oauthSettings: OAuthPromptSettings = {
-  connectionName: process.env.OAUTH_CONNECTION_NAME!, // Configured in Azure Bot resource
-  text: "Please sign in to continue.",
-  title: "Sign In",
-  timeout: 300000, // 5 minutes
-};
-
-const oauthPrompt = new OAuthPrompt("oauthPrompt", oauthSettings);
-
-// In a WaterfallDialog:
-async (step) => {
-  return step.beginDialog("oauthPrompt");
-},
-async (step) => {
-  const tokenResponse = step.result;
-  if (tokenResponse?.token) {
-    // Use tokenResponse.token to call Graph API
-    const graphClient = Client.init({
-      authProvider: (done) => done(null, tokenResponse.token),
-    });
-    const me = await graphClient.api("/me").get();
-    await step.context.sendActivity(`Hello, ${me.displayName}!`);
-  } else {
-    await step.context.sendActivity("Sign-in failed. Please try again.");
-  }
-  return step.endDialog();
-},
-```
-
-**Azure Bot OAuth connection setup**:
-1. Azure Portal > Bot resource > Configuration > OAuth Connection Settings.
-2. Add a new connection with service provider `Azure Active Directory v2`.
-3. Set `Client ID`, `Client Secret`, `Tenant ID`.
-4. Scopes: `openid profile User.Read` (add more as needed).
-5. Use the connection name in `OAuthPromptSettings.connectionName`.
-
-### Tab SSO (getAuthToken + OBO)
-
-1. **Client**: Call `authentication.getAuthToken()` from Teams JS SDK — returns an ID token.
-2. **Server**: Exchange the ID token for an access token via the On-Behalf-Of (OBO) flow.
-3. **Graph calls**: Use the exchanged access token to call Microsoft Graph.
-
-**Azure AD app registration requirements for SSO**:
-- **Redirect URI**: `https://<domain>/auth-end` (SPA platform).
-- **Expose an API**: Add `api://<domain>/<client-id>` as Application ID URI.
-- **Add scope**: `access_as_user` delegated scope.
-- **Authorized client applications**: Add Teams client IDs:
-  - `1fec8e78-bce4-4aaf-ab1b-5451cc387264` (Teams desktop/mobile)
-  - `5e3ce6c0-2b1f-4285-8d4b-75ee78787346` (Teams web)
-
-## 10. Permissions and Scopes
+## 14. Permissions and Scopes
 
 ### Bot Scopes
 
@@ -1106,51 +1767,30 @@ async (step) => {
 
 ### RSC Permissions (Resource-Specific Consent)
 
-RSC allows apps to access data within a specific team or chat without tenant-wide admin consent.
-
 | Permission | Type | Scope |
 |-----------|------|-------|
 | `TeamSettings.Read.Group` | Application | Read team settings |
 | `TeamSettings.ReadWrite.Group` | Application | Read/write team settings |
 | `ChannelMessage.Read.Group` | Application | Read channel messages |
 | `ChatMessage.Read.Chat` | Application | Read chat messages |
-| `ChatSettings.Read.Chat` | Application | Read chat settings |
-| `ChatSettings.ReadWrite.Chat` | Application | Read/write chat settings |
-| `ChatMember.Read.Chat` | Application | Read chat membership |
+| `OnlineMeeting.ReadBasic.Chat` | Delegated | Read meeting details |
+| `MeetingStage.Write.Chat` | Delegated | Share to meeting stage |
 | `TeamsActivity.Send.Group` | Application | Send activity feed notifications |
 | `TeamsActivity.Send.Chat` | Application | Send activity feed in chats |
 | `TeamsActivity.Send.User` | Application | Send activity feed to users |
 
-### Graph Permissions for App Management
-
-| Permission | Type | Allows |
-|-----------|------|--------|
-| `AppCatalog.Read.All` | Application | List org-published apps |
-| `AppCatalog.Submit` | Delegated | Publish/update/delete apps in catalog |
-| `TeamsAppInstallation.ReadForTeam` | Delegated | List apps installed in a team |
-| `TeamsAppInstallation.ReadWriteForTeam` | Delegated | Install/remove apps in teams |
-| `TeamsAppInstallation.ReadForUser` | Delegated | List apps installed for a user |
-| `TeamsAppInstallation.ReadWriteForUser` | Delegated | Install/remove apps for users |
-| `TeamsAppInstallation.ReadWriteSelfForTeam` | Application | Self-manage in teams |
-
-## 11. Error Handling
+## 15. Error Handling
 
 ### Bot `onTurnError`
-
-Always configure a global error handler on the adapter to prevent silent failures.
 
 ```typescript
 import { CloudAdapter, TurnContext } from "botbuilder";
 
-const adapter = new CloudAdapter();
+const adapter = new CloudAdapter(botFrameworkAuthentication);
 
 adapter.onTurnError = async (context: TurnContext, error: Error) => {
   console.error(`[onTurnError] unhandled error: ${error.message}`, error.stack);
-
-  // Send a friendly message to the user
   await context.sendActivity("Sorry, something went wrong. Please try again later.");
-
-  // Clear conversation state to prevent stuck dialogs
   await conversationState.delete(context);
 };
 ```
@@ -1159,339 +1799,159 @@ adapter.onTurnError = async (context: TurnContext, error: Error) => {
 
 | Error | Cause | Fix |
 |-------|-------|-----|
-| `MissingRequiredProperty` | Required field not set in manifest | Add the missing field (`name`, `description`, `icons`, etc.) |
+| `MissingRequiredProperty` | Required field not set | Add the missing field |
 | `InvalidGuid` | `id` or `botId` is not a valid GUID | Use `crypto.randomUUID()` or Azure-generated GUID |
-| `InvalidDomain` | `validDomains` entry is not a valid domain | Use FQDN without protocol (e.g., `contoso.com`, not `https://contoso.com`) |
-| `BotIdMismatch` | Bot ID in manifest doesn't match Azure Bot registration | Ensure `bots[].botId` matches the Azure Bot's Microsoft App ID |
-| `IconSizeMismatch` | `color.png` not 192x192 or `outline.png` not 32x32 | Resize icons to required dimensions |
-| `DescriptionTooLong` | Short description >80 chars or full >4000 chars | Shorten the description text |
+| `InvalidDomain` | `validDomains` entry malformed | Use FQDN without protocol |
+| `BotIdMismatch` | Bot ID mismatch with Azure registration | Ensure `bots[].botId` matches Azure Bot's App ID |
+| `IconSizeMismatch` | Icon dimensions wrong | `color.png` = 192x192, `outline.png` = 32x32 |
+| `DescriptionTooLong` | Short >80 chars or full >4000 chars | Shorten text |
+| `RegexValidationBug` | v1.25 schema rejects valid regex | Validate locally with `m365agents validate` |
 
 ### Sideloading Errors
 
 | Error | Cause | Fix |
 |-------|-------|-----|
-| `SideloadingNotEnabled` | Org policy blocks custom app uploads | Admin must enable "Upload custom apps" in Teams admin center |
-| `AppPackageInvalid` | ZIP structure incorrect | ZIP must contain `manifest.json`, `color.png`, `outline.png` at root level |
-| `ManifestSchemaError` | Manifest doesn't match schema | Run `teamsapp validate` and fix reported issues |
-| `BotNotRegistered` | Bot ID not registered in Bot Framework | Create Azure Bot resource with matching App ID |
+| `SideloadingNotEnabled` | Org policy blocks custom apps | Admin enables "Upload custom apps" in Teams admin center |
+| `AppPackageInvalid` | ZIP structure incorrect | ZIP must contain files at root level |
+| `ManifestSchemaError` | Manifest doesn't match schema | Run `m365agents validate` |
+| `BotNotRegistered` | Bot ID not registered | Create Azure Bot resource with matching App ID |
 
-### Adaptive Card Rendering Fallback
+## 16. Common Patterns
 
-When a card uses features newer than the client's supported schema version:
-
-```json
-{
-  "type": "AdaptiveCard",
-  "version": "1.5",
-  "fallbackText": "This card requires a newer version of Teams to render.",
-  "body": [
-    {
-      "type": "Table",
-      "fallback": {
-        "type": "TextBlock",
-        "text": "Data table (update Teams to see the formatted table)"
-      },
-      "columns": [
-        { "width": 1 },
-        { "width": 2 }
-      ],
-      "rows": [
-        {
-          "type": "TableRow",
-          "cells": [
-            { "type": "TableCell", "items": [{ "type": "TextBlock", "text": "Name" }] },
-            { "type": "TableCell", "items": [{ "type": "TextBlock", "text": "Contoso" }] }
-          ]
-        }
-      ]
-    }
-  ]
-}
-```
-
-## 12. Common Patterns
-
-### Pattern 1: Conversational Bot with Card Actions
-
-A bot that responds to messages and presents Adaptive Cards with `Action.Execute` for interactive workflows.
+### Pattern 1: Meeting App with Side Panel and Stage
 
 ```typescript
-import { TeamsActivityHandler, TurnContext, CardFactory, AdaptiveCardInvokeResponse, AdaptiveCardInvokeValue } from "botbuilder";
+import { TeamsActivityHandler, TurnContext, CardFactory } from "botbuilder";
 
-export class ApprovalBot extends TeamsActivityHandler {
+export class MeetingBot extends TeamsActivityHandler {
   constructor() {
     super();
+
     this.onMessage(async (context, next) => {
-      if (context.activity.text?.includes("request")) {
+      const meetingId = context.activity.channelData?.meeting?.id;
+
+      if (meetingId && context.activity.text?.includes("share")) {
+        // Send content bubble notification during meeting
         const card = CardFactory.adaptiveCard({
           type: "AdaptiveCard",
           version: "1.5",
           body: [
-            { type: "TextBlock", text: "New Approval Request", weight: "Bolder", size: "Medium" },
-            { type: "TextBlock", text: `From: ${context.activity.from.name}`, wrap: true },
-            { type: "Input.Text", id: "reason", label: "Reason", isMultiline: true },
+            { type: "TextBlock", text: "Ready to share to stage?", weight: "Bolder" },
           ],
           actions: [
-            { type: "Action.Execute", title: "Approve", verb: "approve", data: { requestId: "REQ-001" } },
-            { type: "Action.Execute", title: "Reject", verb: "reject", data: { requestId: "REQ-001" } },
+            { type: "Action.Execute", title: "Share Now", verb: "shareToStage", data: { meetingId } },
           ],
         });
-        await context.sendActivity({ attachments: [card] });
+
+        await context.sendActivity({
+          type: "message",
+          attachments: [card],
+          channelData: {
+            notification: { alertInMeeting: true },
+          },
+        });
       }
+
       await next();
     });
   }
 
-  async onAdaptiveCardInvoke(context: TurnContext, invokeValue: AdaptiveCardInvokeValue): Promise<AdaptiveCardInvokeResponse> {
-    const { verb, data } = invokeValue.action;
-    const actor = context.activity.from.name;
-
-    const statusCard = {
-      type: "AdaptiveCard",
-      version: "1.5",
-      body: [
-        { type: "TextBlock", text: `Request ${data.requestId}`, weight: "Bolder" },
-        { type: "TextBlock", text: `**${verb === "approve" ? "Approved" : "Rejected"}** by ${actor}` },
-      ],
-    };
-
-    return { statusCode: 200, type: "application/vnd.microsoft.card.adaptive", value: statusCard };
+  async onAdaptiveCardInvoke(context: TurnContext, invokeValue: any) {
+    if (invokeValue.action.verb === "shareToStage") {
+      return {
+        statusCode: 200,
+        type: "application/vnd.microsoft.activity.message",
+        value: "Content shared to stage!",
+      };
+    }
+    return { statusCode: 200, type: "application/vnd.microsoft.activity.message", value: "OK" };
   }
 }
 ```
 
-### Pattern 2: Search Message Extension
+### Pattern 2: Full Meeting Message Extension
 
-A message extension that queries an external API and returns results as Adaptive Cards.
+A message extension that adapts its behavior based on meeting context.
 
 ```typescript
-import { TeamsActivityHandler, TurnContext, CardFactory, MessagingExtensionQuery, MessagingExtensionResponse } from "botbuilder";
-
-interface SearchResult {
-  id: string;
-  title: string;
-  description: string;
-  imageUrl: string;
-}
-
-export class SearchExtensionBot extends TeamsActivityHandler {
+export class MeetingExtensionBot extends TeamsActivityHandler {
   async handleTeamsMessagingExtensionQuery(
     context: TurnContext,
     query: MessagingExtensionQuery
   ): Promise<MessagingExtensionResponse> {
+    const meetingId = context.activity.channelData?.meeting?.id;
     const searchText = query.parameters?.[0]?.value || "";
-    const results: SearchResult[] = await this.search(searchText);
 
-    const attachments = results.map((item) => ({
+    const items = meetingId
+      ? await this.getMeetingAgendaItems(meetingId, searchText)
+      : await this.getAllItems(searchText);
+
+    const attachments = items.map((item) => ({
       contentType: "application/vnd.microsoft.card.adaptive",
       content: {
         type: "AdaptiveCard",
         version: "1.5",
         body: [
-          { type: "TextBlock", text: item.title, weight: "Bolder", size: "Medium" },
-          { type: "Image", url: item.imageUrl, size: "Medium" },
+          { type: "TextBlock", text: item.title, weight: "Bolder" },
           { type: "TextBlock", text: item.description, wrap: true },
         ],
       },
-      preview: CardFactory.heroCard(item.title, item.description, [item.imageUrl]),
+      preview: CardFactory.heroCard(item.title, item.description),
     }));
 
     return { composeExtension: { type: "result", attachmentLayout: "list", attachments } };
   }
-
-  private async search(query: string): Promise<SearchResult[]> {
-    const response = await fetch(`https://api.contoso.com/search?q=${encodeURIComponent(query)}`);
-    return response.json();
-  }
 }
 ```
 
-### Pattern 3: Action Extension with Task Module
-
-An action message extension that opens a form (task module), collects input, and posts a result card.
+### Pattern 3: Search Message Extension with SSO
 
 ```typescript
-import { TeamsActivityHandler, TurnContext, CardFactory, MessagingExtensionAction, MessagingExtensionActionResponse } from "botbuilder";
-
-export class ActionExtensionBot extends TeamsActivityHandler {
-  async handleTeamsMessagingExtensionFetchTask(
+export class SSOSearchExtension extends TeamsActivityHandler {
+  async handleTeamsMessagingExtensionQuery(
     context: TurnContext,
-    action: MessagingExtensionAction
-  ): Promise<MessagingExtensionActionResponse> {
-    return {
-      task: {
-        type: "continue",
-        value: {
-          title: "Submit Feedback",
-          width: "medium",
-          height: "medium",
-          card: CardFactory.adaptiveCard({
-            type: "AdaptiveCard",
-            version: "1.5",
-            body: [
-              { type: "Input.Text", id: "feedback", label: "Your feedback", isMultiline: true },
-              {
-                type: "Input.ChoiceSet",
-                id: "rating",
-                label: "Rating",
-                choices: [
-                  { title: "Excellent", value: "5" },
-                  { title: "Good", value: "4" },
-                  { title: "Average", value: "3" },
-                  { title: "Poor", value: "2" },
-                  { title: "Terrible", value: "1" },
-                ],
-              },
-            ],
-            actions: [{ type: "Action.Submit", title: "Submit" }],
-          }),
+    query: MessagingExtensionQuery
+  ): Promise<MessagingExtensionResponse> {
+    const searchText = query.parameters?.[0]?.value || "";
+
+    // Get Graph token via SSO for the current user
+    const tokenResponse = await this.getGraphToken(context);
+    if (!tokenResponse) {
+      // Return auth card if SSO fails
+      return {
+        composeExtension: {
+          type: "auth",
+          suggestedActions: {
+            actions: [{ type: "openUrl", value: this.getAuthUrl(), title: "Sign in" }],
+          },
         },
-      },
-    };
-  }
+      };
+    }
 
-  async handleTeamsMessagingExtensionSubmitAction(
-    context: TurnContext,
-    action: MessagingExtensionAction
-  ): Promise<MessagingExtensionActionResponse> {
-    const { feedback, rating } = action.data;
-
-    return {
-      composeExtension: {
-        type: "result",
-        attachmentLayout: "list",
-        attachments: [
-          CardFactory.adaptiveCard({
-            type: "AdaptiveCard",
-            version: "1.5",
-            body: [
-              { type: "TextBlock", text: "Feedback Submitted", weight: "Bolder", size: "Medium" },
-              { type: "FactSet", facts: [
-                { title: "Rating", value: `${"★".repeat(Number(rating))}${"☆".repeat(5 - Number(rating))}` },
-                { title: "Feedback", value: feedback },
-                { title: "Submitted by", value: context.activity.from.name },
-              ]},
-            ],
-          }),
-        ],
-      },
-    };
-  }
-}
-```
-
-### Pattern 4: Tab App with SSO and Graph Data
-
-A React tab that authenticates via SSO and fetches the user's profile from Microsoft Graph.
-
-```typescript
-// src/components/ProfileTab.tsx
-import React, { useEffect, useState } from "react";
-import { app, authentication } from "@microsoft/teams-js";
-import { Spinner, Text, Avatar, Card, CardHeader } from "@fluentui/react-components";
-
-interface UserProfile {
-  displayName: string;
-  mail: string;
-  jobTitle: string;
-  officeLocation: string;
-}
-
-export function ProfileTab() {
-  const [profile, setProfile] = useState<UserProfile | null>(null);
-  const [error, setError] = useState<string>("");
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    (async () => {
-      try {
-        await app.initialize();
-        const token = await authentication.getAuthToken();
-
-        // Send token to backend for OBO exchange
-        const response = await fetch("/api/profile", {
-          headers: { Authorization: `Bearer ${token}` },
-        });
-
-        if (!response.ok) throw new Error(`API error: ${response.status}`);
-        const data: UserProfile = await response.json();
-        setProfile(data);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to load profile");
-      } finally {
-        setLoading(false);
-      }
-    })();
-  }, []);
-
-  if (loading) return <Spinner label="Loading profile..." />;
-  if (error) return <Text style={{ color: "red" }}>{error}</Text>;
-  if (!profile) return null;
-
-  return (
-    <Card>
-      <CardHeader
-        image={<Avatar name={profile.displayName} size={48} />}
-        header={<Text weight="bold">{profile.displayName}</Text>}
-        description={profile.jobTitle}
-      />
-      <Text>Email: {profile.mail}</Text>
-      <Text>Office: {profile.officeLocation}</Text>
-    </Card>
-  );
-}
-```
-
-```typescript
-// src/api/profile.ts (Express backend)
-import { Router } from "express";
-import { ConfidentialClientApplication } from "@azure/msal-node";
-import { Client } from "@microsoft/microsoft-graph-client";
-
-const router = Router();
-
-const msalClient = new ConfidentialClientApplication({
-  auth: {
-    clientId: process.env.AZURE_CLIENT_ID!,
-    clientSecret: process.env.AZURE_CLIENT_SECRET!,
-    authority: `https://login.microsoftonline.com/${process.env.AZURE_TENANT_ID}`,
-  },
-});
-
-router.get("/api/profile", async (req, res) => {
-  const ssoToken = req.headers.authorization?.replace("Bearer ", "");
-  if (!ssoToken) return res.status(401).json({ error: "No token provided" });
-
-  try {
-    const result = await msalClient.acquireTokenOnBehalfOf({
-      oboAssertion: ssoToken,
-      scopes: ["https://graph.microsoft.com/User.Read"],
-    });
-
+    // Search with Graph API using user's token
     const graphClient = Client.init({
-      authProvider: (done) => done(null, result!.accessToken),
+      authProvider: (done) => done(null, tokenResponse.token),
     });
 
-    const profile = await graphClient
-      .api("/me")
-      .select("displayName,mail,jobTitle,officeLocation")
-      .get();
+    const results = await graphClient
+      .api("/search/query")
+      .post({ requests: [{ entityTypes: ["driveItem"], query: { queryString: searchText } }] });
 
-    res.json(profile);
-  } catch (err) {
-    res.status(500).json({ error: "Failed to fetch profile" });
+    const attachments = results.value[0]?.hitsContainers?.[0]?.hits?.map((hit: any) => ({
+      contentType: "application/vnd.microsoft.card.adaptive",
+      content: {
+        type: "AdaptiveCard",
+        version: "1.5",
+        body: [
+          { type: "TextBlock", text: hit.resource.name, weight: "Bolder" },
+          { type: "TextBlock", text: hit.summary || "", wrap: true },
+        ],
+        actions: [{ type: "Action.OpenUrl", title: "Open", url: hit.resource.webUrl }],
+      },
+      preview: CardFactory.heroCard(hit.resource.name, hit.summary || ""),
+    })) || [];
+
+    return { composeExtension: { type: "result", attachmentLayout: "list", attachments } };
   }
-});
-
-export default router;
+}
 ```
-
-## Progressive Disclosure — Reference Files
-
-| Topic | File |
-|---|---|
-| Adaptive Cards schema 1.6, actions, templates, Universal Actions | [`references/adaptive-cards.md`](./references/adaptive-cards.md) |
-| Bot Framework SDK v4, TeamsActivityHandler, proactive messaging | [`references/bot-framework.md`](./references/bot-framework.md) |
-| Tab manifest, Teams JS SDK v2, SSO, configuration pages, deep links | [`references/tabs-personal-group.md`](./references/tabs-personal-group.md) |
-| Message extensions — search, action, link unfurling | [`references/message-extensions.md`](./references/message-extensions.md) |
-| Teams Toolkit CLI — scaffold, preview, provision, deploy, CI/CD | [`references/toolkit-cli.md`](./references/toolkit-cli.md) |

--- a/teams-app-dev/skills/teams-app-dev/references/adaptive-cards.md
+++ b/teams-app-dev/skills/teams-app-dev/references/adaptive-cards.md
@@ -2,27 +2,26 @@
 
 ## Overview
 
-Adaptive Cards are a cross-host JSON card format used throughout Teams for bots, message extensions, notifications, and meeting extensions. Schema version 1.6 is the current maximum supported by Teams. This reference covers the full card schema, actions, data binding templates, Universal Actions, Teams-specific rendering quirks, and error handling.
+Adaptive Cards are a cross-host JSON card format used throughout Teams for bots, message extensions, notifications, and meeting extensions.
 
----
+## Schema Version Support by Client
 
-## Schema Version Support
-
-| Teams Client | Max Schema Version | Notes |
+| Teams Client | Max Schema | Notes |
 |---|---|---|
-| Teams Desktop (Windows) | 1.6 | Full feature set |
-| Teams Desktop (macOS) | 1.6 | Full feature set |
-| Teams Mobile (iOS) | 1.5 | Some 1.6 elements fall back |
-| Teams Mobile (Android) | 1.5 | Some 1.6 elements fall back |
-| Teams Web | 1.6 | Feature parity with desktop |
-| Outlook (via connector) | 1.4 | Older schema; avoid 1.5+ elements |
+| Teams Desktop (Windows/Mac) | 1.6 | Full feature set |
+| Teams Web | 1.6 | Full feature set |
+| **Teams Mobile (iOS)** | **1.2** | Cards >1.2 may not render correctly |
+| **Teams Mobile (Android)** | **1.2** | Cards >1.2 may not render correctly |
+| Outlook (connector) | 1.4 | Avoid 1.5+ elements |
 
-Always declare the schema version you use:
+> **Critical mobile limitation**: Teams mobile supports Adaptive Cards up to v1.2 only. Features unsupported on mobile: `Table`, `Icon`, `isEnabled` on `Action.Submit`, file/image uploads, positive/destructive action styling.
+
+Always declare the schema version:
 ```json
 {
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
   "type": "AdaptiveCard",
-  "version": "1.6"
+  "version": "1.5"
 }
 ```
 
@@ -35,7 +34,7 @@ Always declare the schema version you use:
 ```json
 {
   "type": "AdaptiveCard",
-  "version": "1.6",
+  "version": "1.5",
   "body": [
     {
       "type": "Container",
@@ -46,20 +45,11 @@ Always declare the schema version you use:
           "type": "ColumnSet",
           "columns": [
             {
-              "type": "Column",
-              "width": "auto",
-              "items": [
-                {
-                  "type": "Image",
-                  "url": "https://example.com/logo.png",
-                  "size": "Small",
-                  "style": "Person"
-                }
-              ]
+              "type": "Column", "width": "auto",
+              "items": [{ "type": "Image", "url": "https://example.com/logo.png", "size": "Small", "style": "Person" }]
             },
             {
-              "type": "Column",
-              "width": "stretch",
+              "type": "Column", "width": "stretch",
               "items": [
                 { "type": "TextBlock", "text": "John Smith", "weight": "Bolder" },
                 { "type": "TextBlock", "text": "Engineering", "isSubtle": true, "spacing": "None" }
@@ -70,96 +60,13 @@ Always declare the schema version you use:
       ]
     },
     {
-      "type": "TextBlock",
-      "text": "**Status:** {{status}}",
-      "wrap": true,
-      "markdown": true
-    },
-    {
       "type": "FactSet",
       "facts": [
-        { "title": "Priority", "value": "{{priority}}" },
-        { "title": "Due Date", "value": "{{dueDate}}" },
-        { "title": "Assigned To", "value": "{{assignedTo}}" }
+        { "title": "Priority", "value": "High" },
+        { "title": "Due Date", "value": "2026-03-15" }
       ]
-    },
-    {
-      "type": "Image",
-      "url": "https://example.com/chart.png",
-      "altText": "Weekly trend chart",
-      "size": "Stretch"
     }
   ]
-}
-```
-
-### TextBlock Properties
-
-```json
-{
-  "type": "TextBlock",
-  "text": "Alert: **Service degraded** on {{serviceName}}",
-  "color": "Attention",
-  "size": "Large",
-  "weight": "Bolder",
-  "wrap": true,
-  "maxLines": 3,
-  "fontType": "Monospace",
-  "horizontalAlignment": "Left",
-  "isSubtle": false,
-  "markdown": true
-}
-```
-
-| Property | Values |
-|----------|--------|
-| `color` | `Default`, `Dark`, `Light`, `Accent`, `Good`, `Warning`, `Attention` |
-| `size` | `Small`, `Default`, `Medium`, `Large`, `ExtraLarge` |
-| `weight` | `Lighter`, `Default`, `Bolder` |
-| `fontType` | `Default`, `Monospace` |
-| `horizontalAlignment` | `Left`, `Center`, `Right` |
-
-### Input Elements
-
-```json
-{
-  "type": "Input.Text",
-  "id": "userComment",
-  "label": "Comment",
-  "placeholder": "Enter your comment...",
-  "isMultiline": true,
-  "maxLength": 500,
-  "isRequired": true,
-  "errorMessage": "Comment is required"
-},
-{
-  "type": "Input.ChoiceSet",
-  "id": "priority",
-  "label": "Priority",
-  "style": "compact",
-  "isRequired": true,
-  "value": "medium",
-  "choices": [
-    { "title": "High", "value": "high" },
-    { "title": "Medium", "value": "medium" },
-    { "title": "Low", "value": "low" }
-  ]
-},
-{
-  "type": "Input.Date",
-  "id": "dueDate",
-  "label": "Due Date",
-  "min": "2026-01-01",
-  "max": "2026-12-31"
-},
-{
-  "type": "Input.Toggle",
-  "id": "sendNotification",
-  "label": "Notify team",
-  "title": "Send a notification to the team",
-  "value": "true",
-  "valueOn": "true",
-  "valueOff": "false"
 }
 ```
 
@@ -167,182 +74,67 @@ Always declare the schema version you use:
 
 ## Card Actions
 
-### Action.Submit (Bot Framework)
-
-Sends card data to the bot as a message activity. Used with Bot Framework bots.
-
-```json
-{
-  "type": "Action.Submit",
-  "title": "Approve",
-  "data": {
-    "action": "approve",
-    "itemId": "{{itemId}}",
-    "additionalData": "context"
-  },
-  "style": "positive"
-}
-```
-
-**Handling in bot (TypeScript):**
-```typescript
-this.onMessage(async (context, next) => {
-  if (context.activity.value) {
-    // Card submit
-    const data = context.activity.value as { action: string; itemId: string };
-    if (data.action === "approve") {
-      await this.handleApproval(context, data.itemId);
-    }
-  }
-  await next();
-});
-```
-
-### Action.OpenUrl
-
-```json
-{
-  "type": "Action.OpenUrl",
-  "title": "View in Azure DevOps",
-  "url": "https://dev.azure.com/org/project/_workitems/edit/{{id}}"
-}
-```
-
-### Action.ShowCard
-
-Reveals an embedded card (inline form or details). No round-trip to the bot.
-
-```json
-{
-  "type": "Action.ShowCard",
-  "title": "Add Comment",
-  "card": {
-    "type": "AdaptiveCard",
-    "body": [
-      {
-        "type": "Input.Text",
-        "id": "comment",
-        "label": "Your comment",
-        "isMultiline": true
-      }
-    ],
-    "actions": [
-      {
-        "type": "Action.Submit",
-        "title": "Submit",
-        "data": { "action": "addComment" }
-      }
-    ]
-  }
-}
-```
-
-### Action.Execute (Universal Actions — Teams Only)
-
-Sends an `adaptiveCard/action` invoke to the bot and refreshes the card in-place. Requires Bot Framework SDK v4.14+ and TeamsActivityHandler.
+### Action.Execute (Universal Actions — Teams Preferred)
 
 ```json
 {
   "type": "Action.Execute",
   "title": "Approve",
   "verb": "approve",
-  "data": {
-    "itemId": "{{itemId}}"
-  },
+  "data": { "itemId": "123" },
   "associatedInputs": "auto"
 }
 ```
 
-**Handling invoke in bot:**
-```typescript
-protected async onAdaptiveCardInvoke(
-  context: TurnContext,
-  invokeValue: AdaptiveCardInvokeValue
-): Promise<AdaptiveCardInvokeResponse> {
-  const { verb, data } = invokeValue.action;
+### Action.Submit (Bot Framework)
 
-  if (verb === "approve") {
-    await this.approveItem(data.itemId);
-
-    // Return updated card
-    return {
-      statusCode: 200,
-      type: "application/vnd.microsoft.card.adaptive",
-      value: this.buildApprovedCard(data.itemId),
-    };
-  }
-
-  return { statusCode: 400, type: "application/vnd.microsoft.error", value: {} };
+```json
+{
+  "type": "Action.Submit",
+  "title": "Submit",
+  "data": { "action": "submit" },
+  "style": "positive"
 }
+```
+
+> Note: `style: "positive"` / `"destructive"` is **not supported** on Teams mobile.
+
+### Action.OpenUrl
+
+```json
+{ "type": "Action.OpenUrl", "title": "View", "url": "https://example.com" }
 ```
 
 ---
 
 ## Card Templates (Data Binding)
 
-Use the Adaptive Cards Templating SDK to separate card structure from data.
-
 ```typescript
-import { AdaptiveCardTemplate } from "adaptivecards-templating";
+import { Template } from "adaptivecards-templating";
 
-const templateJson = {
-  type: "AdaptiveCard",
-  version: "1.6",
-  body: [
-    {
-      type: "TextBlock",
-      text: "Incident: ${title}",
-      weight: "Bolder",
-      size: "Large"
-    },
-    {
-      type: "FactSet",
-      facts: [
-        { title: "Severity", value: "${severity}" },
-        { title: "Owner", value: "${owner.displayName}" },
-        { title: "Created", value: "${formatDateTime(createdAt, 'ddd MMM d')}" }
-      ]
-    },
-    {
-      type: "Container",
-      $when: "${severity == 'Critical'}",
-      style: "attention",
-      items: [
-        { type: "TextBlock", text: "CRITICAL — Immediate action required", color: "Attention" }
-      ]
-    }
-  ]
-};
-
-const template = new AdaptiveCardTemplate(templateJson);
-
+const template = new Template(cardPayload);
 const card = template.expand({
   $root: {
-    title: "Database connection pool exhausted",
+    title: "Incident",
     severity: "Critical",
     owner: { displayName: "On-Call Engineer" },
-    createdAt: new Date().toISOString(),
   }
 });
-
-// card is a plain object — serialize to JSON and attach to bot message
 ```
 
 ---
 
 ## Universal Actions — Refresh Pattern
 
-Auto-refresh a card on open (e.g., for real-time status):
-
 ```json
 {
   "type": "AdaptiveCard",
-  "version": "1.6",
+  "version": "1.5",
   "refresh": {
     "action": {
       "type": "Action.Execute",
       "verb": "refresh",
-      "data": { "taskId": "{{taskId}}" }
+      "data": { "taskId": "123" }
     },
     "userIds": ["<user-aad-object-id>"]
   },
@@ -350,33 +142,49 @@ Auto-refresh a card on open (e.g., for real-time status):
 }
 ```
 
-`userIds` limits which users trigger an automatic refresh invoke. Use `[]` (empty) to refresh for all users (not recommended for high-traffic channels).
+---
+
+## Meeting Content Bubble Card
+
+Cards in content bubbles should be compact:
+
+```json
+{
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    { "type": "TextBlock", "text": "Vote Required", "weight": "Bolder" },
+    { "type": "TextBlock", "text": "Approve the budget?", "wrap": true }
+  ],
+  "actions": [
+    { "type": "Action.Execute", "title": "Yes", "verb": "vote", "data": { "vote": "yes" } },
+    { "type": "Action.Execute", "title": "No", "verb": "vote", "data": { "vote": "no" } }
+  ]
+}
+```
+
+Send as content bubble:
+```typescript
+await context.sendActivity({
+  type: "message",
+  attachments: [CardFactory.adaptiveCard(card)],
+  channelData: { notification: { alertInMeeting: true } },
+});
+```
 
 ---
 
-## Sending Cards from a Bot
+## Mobile Compatibility Checklist
 
-```typescript
-import { CardFactory, MessageFactory } from "botbuilder";
-
-const card = CardFactory.adaptiveCard({
-  type: "AdaptiveCard",
-  version: "1.6",
-  body: [
-    { type: "TextBlock", text: "Hello from bot!", weight: "Bolder" }
-  ],
-  actions: [
-    { type: "Action.Submit", title: "Acknowledge", data: { action: "ack" } }
-  ]
-});
-
-await context.sendActivity(MessageFactory.attachment(card));
-
-// Update an existing card (for Universal Actions)
-const activity = MessageFactory.attachment(CardFactory.adaptiveCard(updatedCard));
-activity.id = context.activity.replyToId;
-await context.updateActivity(activity);
-```
+When generating cards, check these rules for mobile compatibility:
+- [ ] Schema version ≤ 1.2 for cards that must work on mobile
+- [ ] No `Table` element (use `FactSet` or `ColumnSet` instead)
+- [ ] No `Icon` element (use `Image` instead)
+- [ ] No `isEnabled` on `Action.Submit`
+- [ ] No `style: "positive"` or `"destructive"` on actions
+- [ ] No file/image upload inputs
+- [ ] Include `fallbackText` for all cards with v1.3+ elements
+- [ ] Test with both desktop and mobile Teams clients
 
 ---
 
@@ -384,16 +192,13 @@ await context.updateActivity(activity);
 
 | Behavior | Details |
 |---|---|
-| Markdown in TextBlock | `markdown: true` is Teams default; set `markdown: false` to disable |
-| `Action.Submit` with empty data | Teams sends the full input values as `value`; no explicit `data` needed |
-| `Input.*` labels | Teams renders labels above inputs; use `label` property (not a TextBlock before the input) |
-| `Container.bleed` | Bleed only works when container is inside another container with a non-default style |
-| `ImageSet` max images | Teams renders max 5 images in an ImageSet; extras are cropped |
-| Card width | Fixed to channel/chat width; do not rely on pixel widths |
-| `Action.Execute` requires Universal Actions manifest entry | App manifest must include `"supportsFiles": false` and `"composeExtensions"` or bot configuration |
-| Theming (light/dark) | Cards adapt to Teams theme; `color` properties respect theme — avoid hard-coded hex |
-| `RichTextBlock` | Supported in Teams 1.6; use `Inline` for mixed styling within a paragraph |
-| Card size limit | Cards are truncated at ~28 KB in Teams; break large cards into multiple messages |
+| Markdown in TextBlock | `markdown: true` is Teams default |
+| `Input.*` labels | Teams renders labels above inputs; use `label` property |
+| `Container.bleed` | Only works inside another container with non-default style |
+| `ImageSet` max images | 5 rendered; extras cropped |
+| Card width | Fixed to channel/chat width |
+| Theming | Cards adapt to theme; avoid hard-coded hex colors |
+| Card size limit | Truncated at ~28 KB |
 
 ---
 
@@ -401,12 +206,11 @@ await context.updateActivity(activity);
 
 | Code | Meaning | Remediation |
 |------|---------|-------------|
-| `BadRequest` (invoke) | `adaptiveCard/action` payload malformed | Check `verb` and `data` match bot handler expectations |
-| `NotSupported` | Action type not supported in client version | Check schema version; use feature detection |
-| `400` on card send | Card JSON schema validation failed | Validate against `http://adaptivecards.io/schemas/adaptive-card.json` |
-| Card not rendering | Unsupported element for schema version | Downgrade schema or use fallback element |
-| `409` on card update | Activity ID mismatch | Use the original message's `id` for updates, not the reply ID |
-| Input values not received | Bot reads `context.activity.text` not `value` | Adaptive Card submits arrive with no text; always check `value` |
+| `BadRequest` (invoke) | Malformed Action.Execute payload | Check `verb` and `data` |
+| `400` on card send | Schema validation failed | Validate JSON schema |
+| Card not rendering | Unsupported element for client version | Downgrade or add fallback |
+| `409` on card update | Activity ID mismatch | Use original message ID |
+| Input values missing | Bot reads `text` not `value` | Check `context.activity.value` |
 
 ---
 
@@ -414,11 +218,10 @@ await context.updateActivity(activity);
 
 | Resource | Limit | Notes |
 |---|---|---|
-| Card JSON size | 28 KB | Larger cards are truncated without error |
-| Actions per card | 6 (visible); unlimited with `ShowCard` nesting | Teams shows first 6 action buttons |
-| Nested containers | 5 levels | Deeper nesting causes rendering issues |
-| Input.ChoiceSet options | 100 | Practical UX limit is much lower |
-| Card version | 1.6 max | Teams does not support 2.x features |
-| Image URL | HTTPS required | HTTP image URLs are blocked in Teams |
-| Image size (linked) | No hard limit; recommend < 1 MB | Large images slow card rendering |
-| Refresh userIds | 60 users | Use empty array to refresh for all |
+| Card JSON size | 28 KB | Larger cards truncated |
+| Actions per card | 6 visible | Unlimited with `ShowCard` nesting |
+| Nested containers | 5 levels | Deeper nesting causes issues |
+| Input.ChoiceSet options | 100 | Practical UX limit lower |
+| Card version | 1.6 max (desktop/web), 1.2 max (mobile) | |
+| Image URL | HTTPS required | |
+| Refresh userIds | 60 users | |

--- a/teams-app-dev/skills/teams-app-dev/references/bot-framework.md
+++ b/teams-app-dev/skills/teams-app-dev/references/bot-framework.md
@@ -1,22 +1,62 @@
-# Bot Framework SDK v4 — Teams Bots Reference
+# Teams Bots Reference — Teams SDK & Bot Framework
 
 ## Overview
 
-Teams bots are built with Bot Framework SDK v4 using the `TeamsActivityHandler` base class. This reference covers the full handler lifecycle, proactive messaging, conversation references, invoke activities, Azure Bot Service registration, and production deployment patterns.
+Teams bots are built using the `TeamsActivityHandler` base class from the `botbuilder` package. The Bot Framework SDK is now archived (final LTS ended December 2025), but the `botbuilder` packages remain the runtime for Teams bots. For new projects, Microsoft recommends the **Teams SDK** (formerly Teams AI Library, GA in C#/JS, preview in Python) or the **Microsoft 365 Agents SDK** (multi-channel agents).
+
+> **Important**: Bot Framework SDK repos are archived on GitHub and support tickets are no longer serviced as of December 31, 2025. The `botbuilder` npm packages still work but receive no new features. New bots should use Teams SDK or Agents SDK.
 
 ---
 
 ## Package Installation
 
 ```bash
-npm install botbuilder botbuilder-teams @microsoft/botframework-connector
+# Core bot packages (still functional, but no new features)
+npm install botbuilder @microsoft/botframework-connector
+
+# Teams SDK (recommended for new projects)
+npm install @microsoft/teams-sdk
+
 # For TypeScript
 npm install --save-dev @types/node
 ```
 
 ---
 
-## TeamsActivityHandler — Full Handler Reference
+## Single-Tenant Bot Adapter (Required for v1.25)
+
+All new bot registrations must be single-tenant (multi-tenant creation blocked after July 31, 2025).
+
+```typescript
+import {
+  CloudAdapter,
+  ConfigurationServiceClientCredentialFactory,
+  ConfigurationBotFrameworkAuthentication,
+} from "botbuilder";
+
+const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
+  MicrosoftAppId: process.env.BOT_ID!,
+  MicrosoftAppPassword: process.env.BOT_PASSWORD!,
+  MicrosoftAppType: "SingleTenant",
+  MicrosoftAppTenantId: process.env.APP_TENANTID!,
+});
+
+const botFrameworkAuthentication = new ConfigurationBotFrameworkAuthentication(
+  {},
+  credentialsFactory
+);
+
+const adapter = new CloudAdapter(botFrameworkAuthentication);
+
+adapter.onTurnError = async (context, error) => {
+  console.error(`Bot turn error: ${error.message}`, error);
+  await context.sendActivity("An error occurred. Please try again.");
+};
+```
+
+---
+
+## TeamsActivityHandler — Full Reference
 
 ```typescript
 import {
@@ -27,7 +67,6 @@ import {
   TeamsInfo,
   ConversationReference,
   Activity,
-  ActivityTypes,
 } from "botbuilder";
 
 export class MyTeamsBot extends TeamsActivityHandler {
@@ -36,130 +75,76 @@ export class MyTeamsBot extends TeamsActivityHandler {
   constructor() {
     super();
 
-    // ─── Message received ────────────────────────────────────────────────
     this.onMessage(async (context, next) => {
       const text = context.activity.text?.trim().toLowerCase() ?? "";
-
-      // Remove bot mention from text
       const removedMentionText = TurnContext.removeRecipientMention(context.activity);
       const cleanText = removedMentionText?.trim().toLowerCase() ?? text;
 
       if (context.activity.value) {
-        // Adaptive Card Action.Submit
         const data = context.activity.value as Record<string, string>;
         await context.sendActivity(`Received action: ${JSON.stringify(data)}`);
       } else if (cleanText === "help") {
-        await context.sendActivity(MessageFactory.text("Available commands: help, status, report"));
+        await context.sendActivity(MessageFactory.text("Available commands: help, status"));
       } else {
         await context.sendActivity(MessageFactory.text(`Echo: ${cleanText}`));
       }
 
-      // Save conversation reference for proactive messaging
       this.addConversationReference(context.activity);
-
       await next();
     });
 
-    // ─── Members added ────────────────────────────────────────────────────
     this.onTeamsMembersAdded(async (membersAdded, teamInfo, context, next) => {
       for (const member of membersAdded) {
         if (member.id !== context.activity.recipient.id) {
-          await context.sendActivity(
-            MessageFactory.text(`Welcome to the team, ${member.name}!`)
-          );
+          await context.sendActivity(MessageFactory.text(`Welcome, ${member.name}!`));
         }
       }
       await next();
     });
-
-    // ─── Members removed ─────────────────────────────────────────────────
-    this.onTeamsMembersRemoved(async (membersRemoved, teamInfo, context, next) => {
-      for (const member of membersRemoved) {
-        console.log(`Member left: ${member.name}`);
-      }
-      await next();
-    });
-
-    // ─── Channel created ─────────────────────────────────────────────────
-    this.onTeamsChannelCreated(async (channelInfo, teamInfo, context, next) => {
-      await context.sendActivity(
-        MessageFactory.text(`Channel created: ${channelInfo.name}`)
-      );
-      await next();
-    });
-
-    // ─── Channel deleted ─────────────────────────────────────────────────
-    this.onTeamsChannelDeleted(async (channelInfo, teamInfo, context, next) => {
-      console.log(`Channel deleted: ${channelInfo.name}`);
-      await next();
-    });
-
-    // ─── Team renamed ────────────────────────────────────────────────────
-    this.onTeamsTeamRenamedActivity(async (teamInfo, context, next) => {
-      await context.sendActivity(`Team renamed to: ${teamInfo.name}`);
-      await next();
-    });
   }
 
-  // ─── Adaptive Card invoke (Universal Actions) ─────────────────────────
-  protected async onAdaptiveCardInvoke(
-    context: TurnContext,
-    invokeValue: { action: { verb: string; data: Record<string, unknown> } }
-  ) {
+  // Universal Action handler
+  protected async onAdaptiveCardInvoke(context: TurnContext, invokeValue: any) {
     const { verb, data } = invokeValue.action;
-
     if (verb === "approve") {
       return {
         statusCode: 200,
         type: "application/vnd.microsoft.card.adaptive",
-        value: { type: "AdaptiveCard", version: "1.6", body: [
+        value: { type: "AdaptiveCard", version: "1.5", body: [
           { type: "TextBlock", text: `Approved! Item: ${data.itemId}`, color: "Good" }
         ]},
       };
     }
-
     return { statusCode: 400, type: "application/vnd.microsoft.error", value: {} };
   }
 
-  // ─── Task module fetch (message extensions / bots) ────────────────────
-  protected async handleTeamsTaskModuleFetch(
-    context: TurnContext,
-    taskModuleRequest: { data: Record<string, string> }
-  ) {
+  // Dialog handlers (replaces "task module" client-side, but method names unchanged)
+  protected async handleTeamsTaskModuleFetch(context: TurnContext, request: any) {
     return {
       task: {
         type: "continue",
         value: {
-          title: "Task Module",
+          title: "Dialog",
           height: 400,
           width: 600,
           card: CardFactory.adaptiveCard({
-            type: "AdaptiveCard",
-            version: "1.6",
-            body: [{ type: "TextBlock", text: "Task content" }],
-            actions: [{ type: "Action.Submit", title: "Submit", data: { taskAction: "submit" } }]
+            type: "AdaptiveCard", version: "1.5",
+            body: [{ type: "TextBlock", text: "Dialog content" }],
+            actions: [{ type: "Action.Submit", title: "Submit" }]
           }),
         },
       },
     };
   }
 
-  // ─── Task module submit ───────────────────────────────────────────────
-  protected async handleTeamsTaskModuleSubmit(
-    context: TurnContext,
-    taskModuleRequest: { data: Record<string, string> }
-  ) {
-    await context.sendActivity(`Task submitted: ${JSON.stringify(taskModuleRequest.data)}`);
-    return { task: { type: "message", value: "Task complete!" } };
+  protected async handleTeamsTaskModuleSubmit(context: TurnContext, request: any) {
+    await context.sendActivity(`Submitted: ${JSON.stringify(request.data)}`);
+    return { task: { type: "message", value: "Done!" } };
   }
 
   private addConversationReference(activity: Partial<Activity>) {
     const ref = TurnContext.getConversationReference(activity);
     this.conversationRefs.set(activity.from!.id, ref);
-  }
-
-  getConversationRefs() {
-    return this.conversationRefs;
   }
 }
 ```
@@ -168,169 +153,43 @@ export class MyTeamsBot extends TeamsActivityHandler {
 
 ## Proactive Messaging
 
-Proactive messages are sent outside of a user-initiated turn. You need a stored `ConversationReference`.
-
 ```typescript
-import { BotFrameworkAdapter, ConversationReference } from "botbuilder";
+import { ConversationReference, MessageFactory } from "botbuilder";
 
-// Set up adapter (Express example)
-const adapter = new BotFrameworkAdapter({
-  appId: process.env.MicrosoftAppId,
-  appPassword: process.env.MicrosoftAppPassword,
-});
-
-// Store a reference during a normal turn (in the bot handler):
-const ref = TurnContext.getConversationReference(context.activity);
-// Persist ref to DB or in-memory store
-
-// Later, send a proactive message:
 async function sendProactiveMessage(
-  adapter: BotFrameworkAdapter,
+  adapter: CloudAdapter,
   ref: Partial<ConversationReference>,
   text: string
 ) {
-  await adapter.continueConversation(ref, async (proactiveContext) => {
-    await proactiveContext.sendActivity(MessageFactory.text(text));
+  await adapter.continueConversation(ref, async (ctx) => {
+    await ctx.sendActivity(MessageFactory.text(text));
   });
 }
-
-// Start a NEW conversation proactively (in a team channel):
-async function startNewConversation(
-  adapter: BotFrameworkAdapter,
-  teamId: string,
-  channelId: string,
-  serviceUrl: string,
-  tenantId: string
-) {
-  const conversationParams = {
-    isGroup: true,
-    channelData: { channel: { id: channelId } },
-    activity: MessageFactory.text("Hello team!"),
-    bot: { id: process.env.MicrosoftAppId!, name: "MyBot" },
-    members: [],
-    tenantId,
-  };
-
-  const connector = adapter.createConnectorClient(serviceUrl);
-  const response = await connector.conversations.createConversation(conversationParams);
-
-  // Save the new conversation ID for future proactive messages
-  return response.id;
-}
 ```
 
 ---
 
-## Mentioning Users in Messages
+## Meeting Bot Patterns
 
 ```typescript
-import { Mention, MessageFactory } from "botbuilder";
+// Detect meeting context
+const meetingId = context.activity.channelData?.meeting?.id;
 
-async function mentionUser(context: TurnContext) {
-  const mention: Mention = {
-    mentioned: context.activity.from,
-    text: `<at>${context.activity.from.name}</at>`,
-    type: "mention",
-  };
-
-  const activity = MessageFactory.text(`Hi ${mention.text}, please review this.`);
-  activity.entities = [mention];
-
-  await context.sendActivity(activity);
-}
-```
-
----
-
-## Getting Team and Member Information
-
-```typescript
-import { TeamsInfo } from "botbuilder";
-
-// Get team details
-const teamDetails = await TeamsInfo.getTeamDetails(context);
-console.log(teamDetails.name, teamDetails.aadGroupId);
-
-// Get team members
-const members = await TeamsInfo.getTeamMembers(context);
-for (const member of members) {
-  console.log(member.name, member.email, member.aadObjectId);
-}
-
-// Get channels in a team
-const channels = await TeamsInfo.getTeamChannels(context);
-for (const channel of channels) {
-  console.log(channel.name, channel.id);
-}
-
-// Get a single member
-const member = await TeamsInfo.getMember(context, context.activity.from.id);
-```
-
----
-
-## Bot Middleware
-
-```typescript
-import { Middleware, TurnContext } from "botbuilder";
-
-// Logging middleware
-class LoggingMiddleware implements Middleware {
-  async onTurn(context: TurnContext, next: () => Promise<void>) {
-    const start = Date.now();
-    console.log(`[${new Date().toISOString()}] Incoming activity: ${context.activity.type}`);
-
-    await next();
-
-    const duration = Date.now() - start;
-    console.log(`[${new Date().toISOString()}] Turn completed in ${duration}ms`);
-  }
-}
-
-// Register middleware
-adapter.use(new LoggingMiddleware());
-```
-
----
-
-## Express Server Setup
-
-```typescript
-import express from "express";
-import { BotFrameworkAdapter } from "botbuilder";
-import { MyTeamsBot } from "./bot";
-
-const app = express();
-app.use(express.json());
-
-const adapter = new BotFrameworkAdapter({
-  appId: process.env.MicrosoftAppId ?? "",
-  appPassword: process.env.MicrosoftAppPassword ?? "",
+// Send content bubble during meeting
+await context.sendActivity({
+  type: "message",
+  attachments: [card],
+  channelData: {
+    notification: { alertInMeeting: true },
+  },
 });
-
-adapter.onTurnError = async (context, error) => {
-  console.error(`Bot turn error: ${error.message}`, error);
-  await context.sendActivity("An error occurred. Please try again.");
-};
-
-const bot = new MyTeamsBot();
-
-app.post("/api/messages", async (req, res) => {
-  await adapter.processActivity(req, res, async (context) => {
-    await bot.run(context);
-  });
-});
-
-const PORT = process.env.PORT ?? 3978;
-app.listen(PORT, () => console.log(`Bot running on port ${PORT}`));
 ```
 
 ---
 
-## Azure Bot Service Registration
+## Azure Bot Registration (Single-Tenant Bicep)
 
 ```bicep
-// Azure Bot Service + App Service Plan (Bicep)
 resource botService 'Microsoft.BotService/botServices@2022-09-15' = {
   name: 'my-teams-bot'
   location: 'global'
@@ -344,58 +203,43 @@ resource botService 'Microsoft.BotService/botServices@2022-09-15' = {
     msaAppTenantId: subscription().tenantId
   }
 }
-
-resource teamsChannel 'Microsoft.BotService/botServices/channels@2022-09-15' = {
-  parent: botService
-  name: 'MsTeamsChannel'
-  location: 'global'
-  properties: {
-    channelName: 'MsTeamsChannel'
-    properties: {
-      isEnabled: true
-    }
-  }
-}
 ```
 
 ---
 
-## Bot Framework Emulator Configuration
+## Express Server Setup
 
-```json
-// .env for local development
-MicrosoftAppId=
-MicrosoftAppPassword=
-MicrosoftAppType=MultiTenant
-PORT=3978
+```typescript
+import express from "express";
+import { CloudAdapter } from "botbuilder";
+import { MyTeamsBot } from "./bot";
 
-// Bot Framework Emulator connection
-// URL: http://localhost:3978/api/messages
-// AppId: (empty for local testing without auth)
-// AppPassword: (empty for local testing)
-```
+const app = express();
+app.use(express.json());
 
-For testing with real Teams auth locally, use `ngrok`:
-```bash
-ngrok http 3978
-# Then update Bot Service endpoint to: https://<ngrok-id>.ngrok-free.app/api/messages
+const bot = new MyTeamsBot();
+
+app.post("/api/messages", async (req, res) => {
+  await adapter.process(req, res, async (context) => {
+    await bot.run(context);
+  });
+});
+
+const PORT = process.env.PORT ?? 3978;
+app.listen(PORT, () => console.log(`Bot running on port ${PORT}`));
 ```
 
 ---
 
-## Invoke Activities Reference
+## SDK Decision Matrix
 
-| Invoke Name | When Triggered | Response Type |
-|---|---|---|
-| `adaptiveCard/action` | `Action.Execute` on an Adaptive Card | `AdaptiveCardInvokeResponse` |
-| `task/fetch` | Task module open request | `TaskModuleResponse` with `continue` |
-| `task/submit` | Task module form submit | `TaskModuleResponse` with `message` or `continue` |
-| `composeExtension/query` | Message extension search | `MessagingExtensionResponse` |
-| `composeExtension/selectItem` | User selects a search result | `MessagingExtensionResponse` |
-| `composeExtension/submitAction` | Action-based extension submit | `MessagingExtensionActionResponse` |
-| `composeExtension/fetchTask` | Action extension task module open | `TaskModuleResponse` |
-| `composeExtension/queryLink` | Link unfurling | `MessagingExtensionResponse` |
-| `signin/verifyState` | OAuth sign-in callback | No response body |
+| Scenario | Recommended SDK | Notes |
+|----------|----------------|-------|
+| Teams-only bot/tab/ME | **Teams SDK** | GA in C#/JS, preview in Python. Supports MCP and A2A. |
+| Multi-channel agent (Teams + Copilot + Slack) | **Microsoft 365 Agents SDK** | AI-agnostic agent container with multi-channel routing |
+| Existing Bot Framework bot | **Migrate to Teams SDK** | Bot Framework SDK archived Dec 2025 |
+| API-only message extension | **No SDK needed** | OpenAPI spec + manifest only |
+| Agent 365 declarative agent | **Agent 365 SDK** | JS, Python, .NET packages available |
 
 ---
 
@@ -403,14 +247,10 @@ ngrok http 3978
 
 | Error | Meaning | Remediation |
 |-------|---------|-------------|
-| `401 Unauthorized` | App ID or password incorrect | Verify `MicrosoftAppId` and `MicrosoftAppPassword` in env |
-| `403 Forbidden` | Bot not authorized for the team/channel | Ensure bot is installed in the team; check admin policies |
-| `BotNotInConversationMembership` | Proactive message to user where bot not installed | Install bot first or use `createConversation` with the team |
-| `ServiceUrl` mismatch | Proactive message to wrong service URL | Use exact `serviceUrl` from stored `ConversationReference` |
-| `Activity too large` | Message or card exceeds size limits | Split into multiple messages or compress card JSON |
-| `429 Too Many Requests` | Rate limit on Bot Connector | Implement exponential backoff; reduce message frequency |
-| `invoke` returns 500 | Bot threw exception in invoke handler | Wrap invoke handlers in try/catch; return proper error response |
-| Token expired in proactive | Connector client token expired | Use `refreshToken` pattern or short-lived token cache |
+| `401 Unauthorized` | App ID or password incorrect | Verify `BOT_ID`, `BOT_PASSWORD`, `APP_TENANTID` |
+| `403 Forbidden` | Bot not authorized | Ensure bot is installed and single-tenant matches |
+| `BotNotInConversationMembership` | Proactive message failed | Install bot first or use `createConversation` |
+| `429 Too Many Requests` | Rate limit | Implement exponential backoff |
 
 ---
 
@@ -418,10 +258,7 @@ ngrok http 3978
 
 | Resource | Limit | Notes |
 |---|---|---|
-| Message text length | 28,000 characters | Adaptive Card JSON also counts |
-| Proactive messages per second | 1 per second per conversation | Throttling enforced by Bot Connector |
-| Mentions per message | No hard limit | More than 10 degrades UX |
-| Conversation members returned | 10,000 | Use paged `getPagedMembers` for large teams |
-| Task module dimensions | 16px–720px height, 16px–1000px width | Height/width in `continue` response |
-| Bot channel registrations per subscription | 10 (free tier) | Unlimited for paid tier |
-| Simultaneous proactive messages | Throttled by Bot Service | Batch with queue; do not fan out in parallel loops |
+| Message text length | 28,000 characters | |
+| Proactive messages per second | 1 per conversation | Throttled by Bot Connector |
+| Conversation members returned | 10,000 | Use paged `getPagedMembers` |
+| Dialog dimensions | 16–720px height, 16–1000px width | |

--- a/teams-app-dev/skills/teams-app-dev/references/message-extensions.md
+++ b/teams-app-dev/skills/teams-app-dev/references/message-extensions.md
@@ -2,11 +2,19 @@
 
 ## Overview
 
-Message extensions allow users to interact with your app from the Teams compose box, command bar, and message action menu. There are three types: search-based (find and share content), action-based (trigger workflows with a form), and link unfurling (enrich URLs pasted in chat). All are implemented as bots using the Bot Framework.
+Message extensions allow users to interact with your app from the Teams compose box, command bar, and message action menu. There are three types: search-based, action-based, and link unfurling.
+
+**Two implementation tracks**:
+| Track | Description | Bot Required | Registration |
+|-------|------------|-------------|-------------|
+| **Bot-based** | Uses Bot Framework messaging protocol | Yes | Azure Bot (single-tenant) |
+| **API-based** | Uses OpenAPI description, no bot | No | OpenAPI spec only |
+
+API-based message extensions can be created from an OpenAPI description and do not require bot registration, making them ideal for simple search/action scenarios backed by REST APIs.
 
 ---
 
-## Manifest Structure
+## Bot-Based Message Extension Manifest (v1.25)
 
 ```json
 {
@@ -18,7 +26,7 @@ Message extensions allow users to interact with your app from the Teams compose 
           "id": "searchItems",
           "type": "query",
           "title": "Search Work Items",
-          "description": "Find Azure DevOps work items",
+          "description": "Find work items",
           "initialRun": true,
           "fetchTask": false,
           "context": ["compose", "commandBox"],
@@ -37,15 +45,7 @@ Message extensions allow users to interact with your app from the Teams compose 
           "title": "Create Work Item",
           "description": "Create a new work item from this message",
           "fetchTask": true,
-          "context": ["message", "compose", "commandBox"],
-          "parameters": [
-            {
-              "name": "title",
-              "title": "Title",
-              "description": "Work item title",
-              "inputType": "text"
-            }
-          ]
+          "context": ["message", "compose", "commandBox"]
         }
       ],
       "messageHandlers": [
@@ -61,18 +61,43 @@ Message extensions allow users to interact with your app from the Teams compose 
 }
 ```
 
+## API-Based Message Extension Manifest (v1.25)
+
+```json
+{
+  "composeExtensions": [
+    {
+      "composeExtensionType": "apiBased",
+      "apiSpecificationFile": "apiSpecificationFile/openapi.json",
+      "commands": [
+        {
+          "id": "searchProducts",
+          "type": "query",
+          "title": "Search Products",
+          "description": "Find products from the catalog",
+          "parameters": [
+            {
+              "name": "query",
+              "title": "Search",
+              "description": "Product name or SKU",
+              "inputType": "text"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+No `botId` needed — the extension is backed by an HTTP API described in the OpenAPI spec.
+
 ---
 
-## Search-Based Message Extension
+## Search-Based (Bot)
 
 ```typescript
-import {
-  TeamsActivityHandler,
-  TurnContext,
-  MessagingExtensionQuery,
-  MessagingExtensionResponse,
-  CardFactory,
-} from "botbuilder";
+import { TeamsActivityHandler, TurnContext, MessagingExtensionQuery, MessagingExtensionResponse, CardFactory } from "botbuilder";
 
 export class SearchExtensionBot extends TeamsActivityHandler {
   protected async handleTeamsMessagingExtensionQuery(
@@ -80,79 +105,48 @@ export class SearchExtensionBot extends TeamsActivityHandler {
     query: MessagingExtensionQuery
   ): Promise<MessagingExtensionResponse> {
     const searchQuery = query.parameters?.[0]?.value as string ?? "";
-    const initialRun = !searchQuery; // `initialRun: true` triggers with empty query
+    const results = await this.searchItems(searchQuery);
 
-    // Fetch results from your backend
-    const results = await this.searchWorkItems(searchQuery);
-
-    // Build result cards
-    const attachments = results.map((item) => {
-      const card = {
+    const attachments = results.map((item) => ({
+      ...CardFactory.thumbnailCard(
+        `#${item.id}: ${item.title}`,
+        item.state
+      ),
+      content: {
         type: "AdaptiveCard",
-        version: "1.6",
+        version: "1.5",
         body: [
           { type: "TextBlock", text: `#${item.id}: ${item.title}`, weight: "Bolder" },
-          { type: "TextBlock", text: `State: ${item.state} | Priority: ${item.priority}`, isSubtle: true },
+          { type: "TextBlock", text: `State: ${item.state}`, isSubtle: true },
         ],
-        actions: [
-          {
-            type: "Action.OpenUrl",
-            title: "View",
-            url: `https://dev.azure.com/org/project/_workitems/edit/${item.id}`,
-          },
-        ],
-      };
-
-      return {
-        // Card shown in the results list (thumbnail)
-        ...CardFactory.thumbnailCard(
-          `#${item.id}: ${item.title}`,
-          item.state,
-          undefined,
-          [{ type: "openUrl", title: "View", value: `https://dev.azure.com/org/project/_workitems/edit/${item.id}` }]
-        ),
-        // Card inserted into compose box when selected
-        content: card,
-        contentType: "application/vnd.microsoft.card.adaptive",
-        preview: CardFactory.thumbnailCard(
-          `#${item.id}: ${item.title}`,
-          `${item.state} | P${item.priority}`,
-          ["https://dev.azure.com/favicon.ico"]
-        ),
-      };
-    });
+      },
+      contentType: "application/vnd.microsoft.card.adaptive",
+      preview: CardFactory.thumbnailCard(`#${item.id}: ${item.title}`, item.state),
+    }));
 
     return {
       composeExtension: {
         type: "result",
-        attachmentLayout: "list",  // "list" | "grid"
+        attachmentLayout: "list",
         attachments,
       },
     };
-  }
-
-  private async searchWorkItems(query: string) {
-    // Replace with real API call
-    return [
-      { id: 1001, title: "Login page", state: "Active", priority: 1 },
-      { id: 1002, title: "Dashboard", state: "New", priority: 2 },
-    ].filter((i) => !query || i.title.toLowerCase().includes(query.toLowerCase()));
   }
 }
 ```
 
 ---
 
-## Action-Based Message Extension
+## Action-Based (Bot) — Uses Dialog Pattern
 
 ```typescript
+// Fetch task returns a dialog (replaces task module)
 protected async handleTeamsMessagingExtensionFetchTask(
   context: TurnContext,
   action: { commandId: string; messagePayload?: { body?: { content?: string } } }
 ): Promise<{ task: { type: string; value: unknown } }> {
   const prefilledTitle = action.messagePayload?.body?.content?.substring(0, 100) ?? "";
 
-  // Return a task module (Adaptive Card)
   return {
     task: {
       type: "continue",
@@ -162,43 +156,19 @@ protected async handleTeamsMessagingExtensionFetchTask(
         width: 500,
         card: CardFactory.adaptiveCard({
           type: "AdaptiveCard",
-          version: "1.6",
+          version: "1.5",
           body: [
-            { type: "TextBlock", text: "Create Work Item", size: "Large", weight: "Bolder" },
-            {
-              type: "Input.Text",
-              id: "title",
-              label: "Title",
-              value: prefilledTitle,
-              isRequired: true,
-              errorMessage: "Title is required",
-            },
-            {
-              type: "Input.ChoiceSet",
-              id: "type",
-              label: "Type",
-              style: "compact",
-              value: "Task",
+            { type: "Input.Text", id: "title", label: "Title", value: prefilledTitle, isRequired: true },
+            { type: "Input.ChoiceSet", id: "type", label: "Type", style: "compact", value: "Task",
               choices: [
                 { title: "User Story", value: "User Story" },
                 { title: "Task", value: "Task" },
                 { title: "Bug", value: "Bug" },
               ],
             },
-            {
-              type: "Input.Text",
-              id: "description",
-              label: "Description",
-              isMultiline: true,
-            },
+            { type: "Input.Text", id: "description", label: "Description", isMultiline: true },
           ],
-          actions: [
-            {
-              type: "Action.Submit",
-              title: "Create",
-              data: { commandId: action.commandId },
-            },
-          ],
+          actions: [{ type: "Action.Submit", title: "Create" }],
         }),
       },
     },
@@ -207,51 +177,61 @@ protected async handleTeamsMessagingExtensionFetchTask(
 
 protected async handleTeamsMessagingExtensionSubmitAction(
   context: TurnContext,
-  action: {
-    commandId: string;
-    data: { title: string; type: string; description: string; commandId: string };
-    messagePayload?: unknown;
-  }
+  action: { data: { title: string; type: string; description: string } }
 ): Promise<MessagingExtensionResponse> {
   const { title, type, description } = action.data;
-
-  // Create the work item
-  const created = await this.createWorkItem({ title, type, description });
-
-  // Return a card to insert into the compose box
-  const resultCard = CardFactory.adaptiveCard({
-    type: "AdaptiveCard",
-    version: "1.6",
-    body: [
-      { type: "TextBlock", text: `Created: #${created.id} — ${title}`, weight: "Bolder" },
-      { type: "TextBlock", text: `Type: ${type}`, isSubtle: true },
-    ],
-    actions: [
-      {
-        type: "Action.OpenUrl",
-        title: "View",
-        url: `https://dev.azure.com/org/project/_workitems/edit/${created.id}`,
-      },
-    ],
-  });
+  const created = await this.createItem({ title, type, description });
 
   return {
     composeExtension: {
       type: "result",
       attachmentLayout: "list",
-      attachments: [
-        {
-          ...resultCard,
-          preview: CardFactory.thumbnailCard(`#${created.id}: ${title}`, type),
-        },
-      ],
+      attachments: [{
+        ...CardFactory.adaptiveCard({
+          type: "AdaptiveCard",
+          version: "1.5",
+          body: [
+            { type: "TextBlock", text: `Created: #${created.id} — ${title}`, weight: "Bolder" },
+            { type: "TextBlock", text: `Type: ${type}`, isSubtle: true },
+          ],
+        }),
+        preview: CardFactory.thumbnailCard(`#${created.id}: ${title}`, type),
+      }],
     },
   };
 }
+```
 
-private async createWorkItem(data: { title: string; type: string; description: string }) {
-  // Replace with real ADO API call
-  return { id: Math.floor(Math.random() * 9999) };
+---
+
+## Meeting-Aware Message Extension
+
+```typescript
+async handleTeamsMessagingExtensionQuery(
+  context: TurnContext,
+  query: MessagingExtensionQuery
+): Promise<MessagingExtensionResponse> {
+  const searchText = query.parameters?.[0]?.value || "";
+  const meetingId = context.activity.channelData?.meeting?.id;
+
+  const results = meetingId
+    ? await this.searchMeetingItems(meetingId, searchText)
+    : await this.searchAllItems(searchText);
+
+  const attachments = results.map((item) => ({
+    contentType: "application/vnd.microsoft.card.adaptive",
+    content: {
+      type: "AdaptiveCard",
+      version: "1.5",
+      body: [
+        { type: "TextBlock", text: item.title, weight: "Bolder" },
+        { type: "TextBlock", text: item.description, wrap: true },
+      ],
+    },
+    preview: CardFactory.heroCard(item.title, item.description),
+  }));
+
+  return { composeExtension: { type: "result", attachmentLayout: "list", attachments } };
 }
 ```
 
@@ -265,186 +245,35 @@ protected async handleTeamsAppBasedLinkQuery(
   query: { url: string }
 ): Promise<MessagingExtensionResponse> {
   const url = query.url;
+  const match = url.match(/workitems\/edit\/(\d+)/);
+  if (!match) return {};
 
-  // Parse the URL to determine what to show
-  const workItemMatch = url.match(/workitems\/edit\/(\d+)/);
-
-  if (workItemMatch) {
-    const id = parseInt(workItemMatch[1], 10);
-    const item = await this.getWorkItem(id);
-
-    const card = CardFactory.adaptiveCard({
-      type: "AdaptiveCard",
-      version: "1.6",
-      body: [
-        { type: "TextBlock", text: `Work Item #${id}: ${item.title}`, weight: "Bolder", size: "Large" },
-        {
-          type: "FactSet",
-          facts: [
-            { title: "Type", value: item.type },
-            { title: "State", value: item.state },
-            { title: "Assigned To", value: item.assignedTo },
-            { title: "Priority", value: String(item.priority) },
-          ],
-        },
-      ],
-      actions: [
-        { type: "Action.OpenUrl", title: "Open in ADO", url },
-      ],
-    });
-
-    return {
-      composeExtension: {
-        type: "result",
-        attachmentLayout: "list",
-        attachments: [
-          {
-            ...card,
-            preview: CardFactory.thumbnailCard(
-              `#${id}: ${item.title}`,
-              item.state
-            ),
-          },
-        ],
-      },
-    };
-  }
-
-  // Return empty/null to not unfurl this URL
-  return {};
-}
-
-private async getWorkItem(id: number) {
-  return { title: "Sample Item", type: "Task", state: "Active", assignedTo: "Dev", priority: 2 };
-}
-```
-
----
-
-## Result Types
-
-| Layout | Use Case | Card Types Supported |
-|--------|----------|---------------------|
-| `list` | List of items with thumbnail preview | Hero card, thumbnail card, Adaptive Card |
-| `grid` | Grid of image tiles | Hero card (image required) |
-| `message` | Plain message (action extension only) | Text or Adaptive Card |
-| `auth` | Redirect to auth page | Auth URL |
-| `config` | Redirect to config page | Config URL |
-| `silentAuth` | Silent authentication | Token |
-| `botMessagePreview` | Preview before sending (action) | Adaptive Card |
-
----
-
-## Bot Message Preview Pattern (Action Extension)
-
-```typescript
-// Step 1: Return a preview for user to review before sending
-protected async handleTeamsMessagingExtensionSubmitAction(
-  context: TurnContext,
-  action: { botActivityPreview?: Array<{ attachments: unknown[] }>; data: Record<string, string> }
-): Promise<MessagingExtensionResponse | MessagingExtensionActionResponse> {
-  if (!action.botActivityPreview) {
-    // First submit — show preview
-    const previewCard = this.buildResultCard(action.data);
-    return {
-      composeExtension: {
-        type: "botMessagePreview",
-        activityPreview: {
-          type: "message",
-          attachments: [previewCard],
-        },
-      },
-    };
-  }
-
-  // User confirmed — send the card
-  const card = action.botActivityPreview[0]?.attachments?.[0];
-  await context.sendActivity({ type: "message", attachments: [card] });
-  return {};
-}
-
-private buildResultCard(data: Record<string, string>) {
-  return CardFactory.adaptiveCard({
+  const item = await this.getItem(parseInt(match[1], 10));
+  const card = CardFactory.adaptiveCard({
     type: "AdaptiveCard",
-    version: "1.6",
-    body: [{ type: "TextBlock", text: data.title }],
-  });
-}
-```
-
----
-
-## Result Card with Graph Data
-
-```typescript
-// Fetch user info from Graph API and embed in search result
-import { Client } from "@microsoft/microsoft-graph-client";
-
-async function enrichResultWithGraph(
-  graphClient: Client,
-  searchQuery: string
-): Promise<MessagingExtensionResponse> {
-  const users = await graphClient
-    .api("/users")
-    .filter(`startsWith(displayName,'${searchQuery}')`)
-    .select("id,displayName,mail,jobTitle,officeLocation")
-    .top(5)
-    .get();
-
-  const attachments = users.value.map((user: {
-    id: string;
-    displayName: string;
-    mail: string;
-    jobTitle: string;
-    officeLocation: string;
-  }) => {
-    const card = CardFactory.adaptiveCard({
-      type: "AdaptiveCard",
-      version: "1.6",
-      body: [
-        { type: "TextBlock", text: user.displayName, weight: "Bolder" },
-        { type: "TextBlock", text: user.jobTitle, isSubtle: true, spacing: "None" },
-        { type: "TextBlock", text: user.officeLocation, isSubtle: true, spacing: "None" },
-      ],
-      actions: [
-        { type: "Action.OpenUrl", title: "Email", url: `mailto:${user.mail}` },
-      ],
-    });
-
-    return {
-      ...card,
-      preview: CardFactory.thumbnailCard(
-        user.displayName,
-        `${user.jobTitle} — ${user.officeLocation}`,
-        [`https://graph.microsoft.com/v1.0/users/${user.id}/photo/$value`]
-      ),
-    };
+    version: "1.5",
+    body: [
+      { type: "TextBlock", text: `#${item.id}: ${item.title}`, weight: "Bolder" },
+      { type: "FactSet", facts: [
+        { title: "State", value: item.state },
+        { title: "Assigned To", value: item.assignedTo },
+      ]},
+    ],
+    actions: [{ type: "Action.OpenUrl", title: "Open", url }],
   });
 
   return {
     composeExtension: {
       type: "result",
       attachmentLayout: "list",
-      attachments,
+      attachments: [{
+        ...card,
+        preview: CardFactory.thumbnailCard(`#${item.id}: ${item.title}`, item.state),
+      }],
     },
   };
 }
 ```
-
----
-
-## Error Codes
-
-| Error | Meaning | Remediation |
-|-------|---------|-------------|
-| `composeExtension.type` missing | Response object malformed | Always wrap response in `composeExtension` |
-| `400` on query | Query handler threw exception | Wrap in try/catch; return empty results on error |
-| Unfurling not triggered | Domain not listed in `messageHandlers.value.domains` | Add all domains including subdomains |
-| `fetchTask: true` but no `task/fetch` handler | Bot handler not implemented | Implement `handleTeamsMessagingExtensionFetchTask` |
-| Action extension not visible | `context` array missing required value | Add `"message"` to `context` for message actions |
-| Preview card not shown in grid | Card missing image URL | Grid layout requires `image` in preview |
-| `401` on Graph data | Graph token not available | Implement SSO OBO flow for message extensions |
-| Task module not opening | Height/width out of range | Use 16–720 px height, 16–1000 px width |
 
 ---
 
@@ -454,11 +283,9 @@ async function enrichResultWithGraph(
 |---|---|---|
 | Commands per extension | 10 | Mix of query and action types |
 | Parameters per command | 5 | First parameter is primary search field |
-| Search results returned | 25 per query | More results are discarded |
-| Query response timeout | 5 seconds | Return cached or fast results; background-load details |
-| Domains in `messageHandlers` | 10 | Wildcards not supported in link unfurling domains |
-| Task module height | 16–720 pixels | Teams clips to min/max |
-| Task module width | 16–1000 pixels | Teams clips to min/max |
-| Preview card title length | 255 characters | Truncated in UI |
+| Search results returned | 25 per query | More results discarded |
+| Query response timeout | 5 seconds | Return fast results |
+| Domains in `messageHandlers` | 10 | Wildcards not supported in link unfurling |
+| Task module / dialog height | 16–720 pixels | Teams clips to min/max |
+| Task module / dialog width | 16–1000 pixels | Teams clips to min/max |
 | Attachment content size | 28 KB | Card JSON limit |
-| `botActivityPreview` previews | 1 | Only one preview card supported |

--- a/teams-app-dev/skills/teams-app-dev/references/tabs-personal-group.md
+++ b/teams-app-dev/skills/teams-app-dev/references/tabs-personal-group.md
@@ -2,36 +2,29 @@
 
 ## Overview
 
-Teams tabs are web pages embedded inside Microsoft Teams using an iframe. There are three main tab types: personal (static), channel/group (configurable), and meeting tabs. This reference covers the manifest structure, Teams JS SDK v2, SSO authentication with MSAL, deep links, tab context objects, and Teams Toolkit scaffolding patterns.
+Teams tabs are web pages embedded inside Microsoft Teams using an iframe. There are three main tab types: personal (static), channel/group (configurable), and meeting tabs. This reference covers manifest v1.25 structure, TeamsJS SDK v2.19+, NAA authentication, deep links, and meeting tab patterns.
+
+> **Requirement**: New app submissions and updates require **TeamsJS v2.19.0 or later**. TeamsJS v1.13.0 receives no new features.
 
 ---
 
-## App Manifest Structure for Tabs
+## App Manifest Structure for Tabs (v1.25)
 
 ```json
 {
-  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.17/MicrosoftTeams.schema.json",
-  "manifestVersion": "1.17",
+  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.25/MicrosoftTeams.schema.json",
+  "manifestVersion": "1.25",
   "version": "1.0.0",
   "id": "{{AAD_APP_CLIENT_ID}}",
-  "name": {
-    "short": "My App",
-    "full": "My Application Full Name"
-  },
-  "description": {
-    "short": "Short description (80 chars max)",
-    "full": "Full description of app capabilities (4000 chars max)"
-  },
+  "name": { "short": "My App", "full": "My Application Full Name" },
+  "description": { "short": "Short description (80 chars max)", "full": "Full description (4000 chars max)" },
   "developer": {
     "name": "Contoso",
     "websiteUrl": "https://contoso.com",
     "privacyUrl": "https://contoso.com/privacy",
     "termsOfUseUrl": "https://contoso.com/tos"
   },
-  "icons": {
-    "color": "color.png",
-    "outline": "outline.png"
-  },
+  "icons": { "color": "color.png", "outline": "outline.png" },
   "accentColor": "#FFFFFF",
 
   "staticTabs": [
@@ -40,12 +33,6 @@ Teams tabs are web pages embedded inside Microsoft Teams using an iframe. There 
       "name": "Home",
       "contentUrl": "https://{{TAB_DOMAIN}}/tab/home",
       "websiteUrl": "https://{{TAB_DOMAIN}}/tab/home",
-      "scopes": ["personal"]
-    },
-    {
-      "entityId": "settingsTab",
-      "name": "Settings",
-      "contentUrl": "https://{{TAB_DOMAIN}}/tab/settings",
       "scopes": ["personal"]
     }
   ],
@@ -63,8 +50,7 @@ Teams tabs are web pages embedded inside Microsoft Teams using an iframe. There 
         "meetingSidePanel",
         "meetingStage"
       ],
-      "sharePointPreviewImage": "https://{{TAB_DOMAIN}}/preview.png",
-      "supportedSharePointHosts": ["sharePointFullPage", "sharePointWebPart"]
+      "supportsChannelFeatures": true
     }
   ],
 
@@ -74,190 +60,79 @@ Teams tabs are web pages embedded inside Microsoft Teams using an iframe. There 
   "webApplicationInfo": {
     "id": "{{AAD_APP_CLIENT_ID}}",
     "resource": "api://{{TAB_DOMAIN}}/{{AAD_APP_CLIENT_ID}}"
+  },
+  "nestedAppAuthInfo": {
+    "oidcScopes": ["openid", "profile", "email", "offline_access"],
+    "accessTokenAcceptedVersion": 2
   }
 }
 ```
 
 ---
 
-## Teams JS SDK v2 — Core API
+## TeamsJS SDK v2 — Core API
+
+```bash
+npm install @microsoft/teams-js@latest  # Must be >= 2.19.0
+```
 
 ```typescript
 import * as microsoftTeams from "@microsoft/teams-js";
 
-// MUST call app.initialize() before any other SDK call
 await microsoftTeams.app.initialize();
-
-// Get full context
 const context = await microsoftTeams.app.getContext();
+
 console.log({
   teamId: context.team?.internalId,
   channelId: context.channel?.id,
-  channelName: context.channel?.displayName,
-  userObjectId: context.user?.id,              // AAD Object ID
-  userPrincipalName: context.user?.userPrincipalName,
-  locale: context.app.locale,
-  theme: context.app.theme,                    // "default" | "dark" | "contrast"
-  entityId: context.page.id,                  // entityId from manifest
-  subPageId: context.page.subPageId,          // deep link sub-page
-  sessionId: context.app.sessionId,
-  hostName: context.app.host.name,            // "Teams" | "Outlook" | "Office"
-  frameContext: context.page.frameContext,    // "content" | "task" | "sidePanel" etc.
+  userObjectId: context.user?.id,
+  theme: context.app.theme,            // "default" | "dark" | "contrast"
+  hostName: context.app.host.name,    // "Teams" | "Outlook" | "Office"
+  frameContext: context.page.frameContext, // "content" | "sidePanel" | "meetingStage"
   meetingId: context.meeting?.id,
 });
 ```
 
 ---
 
-## Tab Configuration Page (Configurable Tab)
+## Nested App Authentication (NAA) — Recommended Default
+
+NAA enables pop-up-free token acquisition using MSAL.js. No TeamsJS `getAuthToken` needed. NAA is GA across Teams, Outlook, and M365 hosts for personal tab apps.
 
 ```typescript
-import * as microsoftTeams from "@microsoft/teams-js";
-import { useEffect, useState } from "react";
+import { PublicClientApplication } from "@azure/msal-browser";
 
-export const ConfigPage: React.FC = () => {
-  const [selectedOption, setSelectedOption] = useState("dashboard");
-
-  useEffect(() => {
-    (async () => {
-      await microsoftTeams.app.initialize();
-
-      // Tell Teams the configuration is valid/invalid
-      microsoftTeams.pages.config.registerOnSaveHandler(async (saveEvent) => {
-        await microsoftTeams.pages.config.setConfig({
-          entityId: `tab-${selectedOption}`,
-          configName: `My Tab - ${selectedOption}`,
-          contentUrl: `https://mytabdomain.com/tab/${selectedOption}?theme={theme}&locale={locale}`,
-          websiteUrl: `https://mytabdomain.com/tab/${selectedOption}`,
-          removeUrl: `https://mytabdomain.com/tab/remove`,
-        });
-        saveEvent.notifySuccess();
-      });
-
-      microsoftTeams.pages.config.registerOnRemoveHandler((removeEvent) => {
-        // Perform cleanup (delete data, etc.)
-        removeEvent.notifySuccess();
-      });
-
-      microsoftTeams.pages.config.setValidityState(true);
-    })();
-  }, [selectedOption]);
-
-  return (
-    <div>
-      <h1>Configure Tab</h1>
-      <select value={selectedOption} onChange={(e) => setSelectedOption(e.target.value)}>
-        <option value="dashboard">Dashboard</option>
-        <option value="reports">Reports</option>
-        <option value="settings">Settings</option>
-      </select>
-    </div>
-  );
-};
-```
-
----
-
-## SSO Authentication with MSAL
-
-### Step 1: Server-side token exchange
-
-```typescript
-// Server endpoint: exchange Teams SSO token for a Graph token
-import { ConfidentialClientApplication } from "@azure/msal-node";
-import express from "express";
-
-const msalClient = new ConfidentialClientApplication({
+const msalConfig = {
   auth: {
-    clientId: process.env.AAD_APP_CLIENT_ID!,
-    clientSecret: process.env.AAD_APP_CLIENT_SECRET!,
-    authority: `https://login.microsoftonline.com/${process.env.AAD_APP_TENANT_ID}`,
+    clientId: process.env.AZURE_CLIENT_ID!,
+    authority: `https://login.microsoftonline.com/${process.env.APP_TENANTID}`,
+    supportsNestedAppAuth: true,  // Enable NAA
   },
+};
+
+const pca = new PublicClientApplication(msalConfig);
+await pca.initialize();
+
+// Acquire token silently — no popup
+const accounts = pca.getAllAccounts();
+const tokenResponse = await pca.acquireTokenSilent({
+  scopes: ["User.Read", "Files.Read"],
+  account: accounts[0],
 });
 
-const router = express.Router();
-
-router.post("/auth/token", async (req, res) => {
-  const { ssoToken } = req.body as { ssoToken: string };
-
-  try {
-    const result = await msalClient.acquireTokenOnBehalfOf({
-      oboAssertion: ssoToken,
-      scopes: ["User.Read", "Files.Read"],
-    });
-
-    res.json({ accessToken: result!.accessToken });
-  } catch (err: unknown) {
-    const error = err as { errorCode?: string };
-    if (error.errorCode === "interaction_required") {
-      // Consent needed — client must trigger full auth flow
-      res.status(403).json({ error: "consent_required" });
-    } else {
-      res.status(500).json({ error: "token_exchange_failed" });
-    }
-  }
-});
+// Use tokenResponse.accessToken for Graph calls directly
+// No server-side OBO exchange needed with NAA
 ```
 
-### Step 2: Client-side SSO token acquisition
+### Traditional SSO (Fallback)
+
+If NAA is not available (older clients), fall back to TeamsJS SSO + server-side OBO:
 
 ```typescript
-import * as microsoftTeams from "@microsoft/teams-js";
+import { authentication } from "@microsoft/teams-js";
 
-async function getGraphAccessToken(): Promise<string> {
-  await microsoftTeams.app.initialize();
-
-  // Get the SSO token from Teams (silent, no popup)
-  const ssoToken = await microsoftTeams.authentication.getAuthToken();
-
-  // Exchange SSO token for Graph token on your server
-  const response = await fetch("/auth/token", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ ssoToken }),
-  });
-
-  if (response.status === 403) {
-    // Consent required — trigger interactive auth
-    await microsoftTeams.authentication.authenticate({
-      url: `${window.location.origin}/auth/start`,
-      width: 600,
-      height: 535,
-    });
-    // Retry after consent
-    return getGraphAccessToken();
-  }
-
-  const data = await response.json() as { accessToken: string };
-  return data.accessToken;
-}
-```
-
----
-
-## Deep Links
-
-Deep links navigate to specific content within Teams.
-
-```typescript
-// Navigate to a tab with a sub-page
-const deepLink = `https://teams.microsoft.com/l/entity/${appId}/${entityId}?webUrl=${encodedWebUrl}&label=${encodedLabel}&context=${encodedContext}`;
-
-// Using TeamsJS SDK v2 (recommended)
-await microsoftTeams.pages.navigateToApp({
-  appId: "your-app-id",
-  pageId: "homeTab",
-  subPageId: "item-123",
-});
-
-// Open a channel in Teams
-const channelLink = `https://teams.microsoft.com/l/channel/${channelId}/${channelName}?groupId=${teamId}&tenantId=${tenantId}`;
-
-// Open a chat
-const chatLink = `https://teams.microsoft.com/l/chat/0/0?users=${userUPN}`;
-
-// Share to Teams
-const shareLink = `https://teams.microsoft.com/share?href=${encodeURIComponent(contentUrl)}&preview=true&referrer=myapp`;
+const ssoToken = await authentication.getAuthToken();
+// Exchange server-side via OBO flow
 ```
 
 ---
@@ -265,15 +140,15 @@ const shareLink = `https://teams.microsoft.com/share?href=${encodeURIComponent(c
 ## Meeting Tab Patterns
 
 ```typescript
-// Detect meeting context
-const context = await microsoftTeams.app.getContext();
+import { meeting, app } from "@microsoft/teams-js";
+
+const context = await app.getContext();
 const isMeeting = !!context.meeting;
 const frameContext = context.page.frameContext;
-// "sidePanel" | "meetingStage" | "content"
 
-// Share content to meeting stage
+// Share to meeting stage from side panel
 if (frameContext === "sidePanel") {
-  await microsoftTeams.meeting.shareAppContentToStage(
+  meeting.shareAppContentToStage(
     (err, result) => {
       if (err) console.error("Share to stage failed:", err);
     },
@@ -281,8 +156,8 @@ if (frameContext === "sidePanel") {
   );
 }
 
-// Get meeting participants (requires meeting organizer permissions)
-microsoftTeams.meeting.getMeetingDetails((err, details) => {
+// Get meeting details
+meeting.getMeetingDetails((err, details) => {
   if (details) {
     console.log("Meeting ID:", details.details.id);
     console.log("Organizer:", details.organizer.id);
@@ -292,37 +167,68 @@ microsoftTeams.meeting.getMeetingDetails((err, details) => {
 
 ---
 
-## Notification API (Tabs)
+## Deep Links
 
 ```typescript
-// Show a notification in the Teams client (not a push notification)
-await microsoftTeams.app.openLink(
-  `https://teams.microsoft.com/l/entity/${appId}/homeTab`
-);
-
-// Send activity notification to user (via Graph API)
-// POST /teams/{teamId}/channels/{channelId}/members/{memberId}/sendActivityNotification
+// Using TeamsJS SDK v2 (recommended)
+await microsoftTeams.pages.navigateToApp({
+  appId: "your-app-id",
+  pageId: "homeTab",
+  subPageId: "item-123",
+});
 ```
 
 ---
 
-## Tab Context Object — Key Fields
+## Dialog Namespace (Replaces Task Modules)
 
-| Field | Path | Description |
-|-------|------|-------------|
-| User AAD ID | `context.user?.id` | AAD Object ID of the current user |
-| User UPN | `context.user?.userPrincipalName` | Email/UPN |
-| Tenant ID | `context.user?.tenant?.id` | Tenant where user is signed in |
-| Team ID | `context.team?.internalId` | Internal Teams team ID |
-| Team AAD Group ID | `context.team?.groupId` | AAD Group ID for Graph calls |
-| Channel ID | `context.channel?.id` | Current channel ID |
-| Entity ID | `context.page.id` | `entityId` from manifest `staticTabs` |
-| Sub-page ID | `context.page.subPageId` | From deep link `subEntityId` |
-| Theme | `context.app.theme` | `"default"` \| `"dark"` \| `"contrast"` |
-| Locale | `context.app.locale` | BCP-47 locale string, e.g. `"en-us"` |
-| Frame context | `context.page.frameContext` | `"content"` \| `"sidePanel"` \| `"task"` |
-| Meeting ID | `context.meeting?.id` | Present only in meeting context |
-| Host name | `context.app.host.name` | `"Teams"` \| `"Outlook"` \| `"Office"` |
+```typescript
+import { dialog, app } from "@microsoft/teams-js";
+
+// Open URL dialog (replaces tasks.startTask)
+dialog.url.open({
+  url: `${window.location.origin}/dialog/form`,
+  title: "Create Item",
+  size: { width: "large", height: "large" },
+}, (result) => {
+  console.log("Dialog result:", result.result);
+});
+
+// Open Adaptive Card dialog
+dialog.adaptiveCard.open({
+  card: JSON.stringify(cardPayload),
+  title: "Feedback",
+  size: { width: "medium", height: "medium" },
+}, (result) => {
+  console.log("Card result:", result.result);
+});
+
+// Submit from inside a dialog iframe
+dialog.url.submit(JSON.stringify(formData));
+```
+
+---
+
+## Adaptive Card Client Compatibility
+
+| Client | Max Schema | Notes |
+|--------|-----------|-------|
+| Teams Desktop (Windows/Mac) | 1.6 | Full feature set |
+| Teams Web | 1.6 | Full feature set |
+| Teams Mobile (iOS) | 1.2 | Cards >1.2 may not render correctly |
+| Teams Mobile (Android) | 1.2 | Cards >1.2 may not render correctly |
+| Outlook | 1.4 | Avoid 1.5+ elements |
+
+> **Mobile limitation**: Teams mobile supports Adaptive Cards up to v1.2. Cards later than 1.2 might not render correctly. `isEnabled` on `Action.Submit`, file/image uploads, and positive/destructive action styling are not supported.
+
+---
+
+## supportsChannelFeatures
+
+For apps that work in shared and private channels, set `supportsChannelFeatures: true` on configurable tabs. Note:
+- Private/shared channels have their own SharePoint sites
+- Don't assume packaging or membership equivalence across channel types
+- The Dev Portal may drop this field on save — always author in code
 
 ---
 
@@ -330,14 +236,11 @@ await microsoftTeams.app.openLink(
 
 | Error | Meaning | Remediation |
 |-------|---------|-------------|
-| `resourceDisabled` | Tab not authorized in tenant | Admin must consent to the app in Teams admin center |
-| `FailedToOpenPage` | Tab URL not in `validDomains` | Add all domains (including auth redirect domains) to `validDomains` |
-| `notSupported` | SDK API not available in this host | Check `microsoftTeams.isAvailable()` before calling APIs |
-| `interaction_required` | SSO consent not granted | Trigger `authentication.authenticate()` for full consent flow |
-| `invalid_grant` | SSO OBO failed | Ensure `api://domain/clientId` resource is in manifest `webApplicationInfo` |
-| CORS error on token exchange | Server not accepting `Origin` header | Configure CORS to allow Teams domain origins |
-| Blank tab renders | `contentUrl` iframe blocked | Add `X-Frame-Options: ALLOWALL` or use `Content-Security-Policy: frame-ancestors` |
-| Config page save button disabled | `setValidityState(false)` not called | Call `setValidityState(true)` in configuration page `useEffect` |
+| `FailedToOpenPage` | Tab URL not in `validDomains` | Add all domains to `validDomains` |
+| `notSupported` | SDK API not available in this host | Check capability before calling |
+| `interaction_required` | SSO consent not granted | Use `authentication.authenticate()` or NAA fallback |
+| CORS error | Server not accepting origin | Configure CORS for Teams domains |
+| Blank tab | iframe blocked | Use `Content-Security-Policy: frame-ancestors` |
 
 ---
 
@@ -345,12 +248,9 @@ await microsoftTeams.app.openLink(
 
 | Resource | Limit | Notes |
 |---|---|---|
-| Tab content URL | HTTPS only | HTTP blocked in Teams |
-| `validDomains` entries | 16 | Wildcards supported: `*.contoso.com` |
-| Static tabs per app | 16 | Shown in personal app side rail |
-| Configurable tabs per app | 1 | One `configurableTabs` entry in manifest |
-| `configurationUrl` query string | 1,024 characters | Avoid long query params |
-| iFrame allowed features | No camera/microphone by default | Request via manifest `devicePermissions` |
-| Meeting stage content URL | Must match `validDomains` | Same iframe restrictions apply |
-| Token expiry (SSO) | 1 hour | Cache access tokens; refresh before expiry |
-| `entityId` length | 64 characters | Used for deep links; keep short and URL-safe |
+| Tab content URL | HTTPS only | HTTP blocked |
+| `validDomains` entries | 16 | Wildcards supported |
+| Static tabs per app | 16 | |
+| Configurable tabs per app | 1 | |
+| Meeting stage content URL | Must match `validDomains` | |
+| Token expiry (SSO) | 1 hour | Cache and refresh |

--- a/teams-app-dev/skills/teams-app-dev/references/toolkit-cli.md
+++ b/teams-app-dev/skills/teams-app-dev/references/toolkit-cli.md
@@ -1,8 +1,10 @@
-# Teams Toolkit CLI Reference
+# M365 Agents Toolkit CLI Reference
 
 ## Overview
 
-Teams Toolkit CLI (`teamsapp`) is the command-line companion to the VS Code Teams Toolkit extension. It provides commands for scaffolding new projects, local debugging, provisioning Azure/M365 resources, deploying apps, and publishing to the Teams App Store. This reference covers all major commands, environment management, Bicep template patterns, and CI/CD integration.
+M365 Agents Toolkit CLI (`m365agents`) is the official command-line tool for Microsoft Teams and Microsoft 365 app development. It replaces the legacy Teams Toolkit CLI (`teamsapp`). It provides commands for scaffolding new projects, local debugging with Agents Playground, provisioning Azure/M365 resources, deploying apps, and publishing to the Teams App Store.
+
+> **Migration note**: The package changed from `@microsoft/teamsapp-cli` to `@microsoft/m365agentstoolkit-cli`. The config file changed from `teamsapp.yml` to `m365agents.yml`. The previous `teamsapp` command is replaced by `m365agents`. TeamsFx SDK is in deprecation mode (community-only GitHub support until September 2026) — new projects must not use TeamsFx.
 
 ---
 
@@ -10,33 +12,36 @@ Teams Toolkit CLI (`teamsapp`) is the command-line companion to the VS Code Team
 
 ```bash
 # Install globally via npm
-npm install -g @microsoft/teamsapp-cli
+npm install -g @microsoft/m365agentstoolkit-cli
 
 # Verify installation
-teamsapp --version
+m365agents --version
+
+# Remove legacy CLI if installed
+npm uninstall -g @microsoft/teamsapp-cli
 
 # Login to M365 (opens browser for consent)
-teamsapp auth login m365
+m365agents auth login m365
 
 # Login to Azure
-teamsapp auth login azure
+m365agents auth login azure
 
 # Check login status
-teamsapp auth list
+m365agents auth list
 ```
 
 ---
 
 ## Project Scaffolding
 
-### `teamsapp new`
+### `m365agents new`
 
 ```bash
 # Interactive project creation
-teamsapp new
+m365agents new
 
 # Non-interactive: create a TypeScript bot project
-teamsapp new \
+m365agents new \
   --interactive false \
   --capabilities bot \
   --programming-language typescript \
@@ -44,7 +49,7 @@ teamsapp new \
   --folder ./projects
 
 # Create a tab app
-teamsapp new \
+m365agents new \
   --interactive false \
   --capabilities tab \
   --programming-language typescript \
@@ -52,19 +57,27 @@ teamsapp new \
   --folder ./projects
 
 # Create a message extension
-teamsapp new \
+m365agents new \
   --interactive false \
   --capabilities message-extension \
   --programming-language typescript \
   --app-name MyExtension \
   --folder ./projects
 
-# Create a bot + tab combination
-teamsapp new \
+# Create a Custom Engine Agent
+m365agents new \
   --interactive false \
-  --capabilities bot,tab \
+  --capabilities custom-engine-agent \
   --programming-language typescript \
-  --app-name MyCombinedApp \
+  --app-name MyAgent \
+  --folder ./projects
+
+# Create an API-based message extension (no bot registration needed)
+m365agents new \
+  --interactive false \
+  --capabilities api-message-extension \
+  --programming-language typescript \
+  --app-name MyApiExtension \
   --folder ./projects
 ```
 
@@ -72,48 +85,54 @@ teamsapp new \
 | Capability | Description |
 |------------|-------------|
 | `tab` | Static or configurable tab |
-| `bot` | Teams bot |
-| `message-extension` | Search or action message extension |
+| `bot` | Teams bot (single-tenant) |
+| `message-extension` | Bot-based search or action message extension |
+| `api-message-extension` | API-based message extension (OpenAPI, no bot needed) |
 | `notification` | Notification-only bot (webhook triggered) |
 | `command-bot` | Bot with command pattern |
 | `workflow-bot` | Bot with adaptive card workflow |
 | `dashboard-tab` | Dashboard tab with widgets |
-| `sso-tab` | Tab with SSO pre-configured |
-| `ai-bot` | Bot with Azure OpenAI integration |
+| `sso-tab` | Tab with SSO + NAA pre-configured |
+| `custom-engine-agent` | Custom Engine Agent with AI capabilities |
+| `declarative-agent` | Declarative agent (Agent 365) |
 
 ---
 
 ## Local Development
 
-### `teamsapp preview`
+### `m365agents preview`
 
 ```bash
-# Start local debug session (launches Teams in browser)
-teamsapp preview --local
+# Start local debug session with Agents Playground (no registration needed)
+m365agents preview --local
 
 # Preview with a specific environment
-teamsapp preview --env local
+m365agents preview --env local
 
 # Preview a remote environment (already deployed)
-teamsapp preview --env dev
+m365agents preview --env dev
 
 # Open in specific browser
-teamsapp preview --local --browser chrome
-
-# Preview without opening browser (headless)
-teamsapp preview --local --open-only-once
+m365agents preview --local --browser chrome
 ```
+
+### Agents Playground
+
+Agents Playground replaces the need for Dev Tunnels and ngrok during local development:
+- Opens at `http://localhost:56150` by default
+- Simulates Teams client environment without Azure Bot registration
+- Supports Adaptive Card rendering, invoke activities, and meeting context simulation
+- No bot registration or tunnel setup required
 
 ### Local dev prerequisites
 
-Teams Toolkit local debug expects:
+M365 Agents Toolkit local debug expects:
 1. A running local server (e.g., `node index.js` on port 3978)
-2. The Teams App Test Tool OR a public tunnel (Dev Tunnels, ngrok)
-3. `teamsapp.local.yml` configured with local environment settings
+2. `m365agents.local.yml` configured with local environment settings
 
 ```yaml
-# teamsapp.local.yml (auto-generated by toolkit)
-version: 1.0.0
+# m365agents.local.yml
+version: v1.6
 
 provision:
   - uses: botFramework/create
@@ -131,92 +150,74 @@ deploy:
       envs:
         MicrosoftAppId: ${{BOT_ID}}
         MicrosoftAppPassword: ${{SECRET_BOT_PASSWORD}}
+        MicrosoftAppTenantId: ${{APP_TENANTID}}
 ```
 
 ---
 
 ## Provisioning
 
-### `teamsapp provision`
-
-Creates or updates Azure and M365 resources defined in Bicep templates.
+### `m365agents provision`
 
 ```bash
 # Provision to dev environment
-teamsapp provision --env dev
+m365agents provision --env dev
 
-# Provision to production (confirm destructive changes)
-teamsapp provision --env production
+# Provision to production
+m365agents provision --env production
 
 # Provision with specific subscription
-teamsapp provision --env dev --subscription <subscription-id>
-
-# Preview what would be provisioned (dry run)
-teamsapp provision --env dev --dry-run
+m365agents provision --env dev --subscription <subscription-id>
 
 # Skip confirmation prompts (for CI/CD)
-teamsapp provision --env dev --no-interactive
+m365agents provision --env dev --no-interactive
 ```
 
 ---
 
 ## Deployment
 
-### `teamsapp deploy`
-
-Builds and deploys app code to Azure resources.
+### `m365agents deploy`
 
 ```bash
 # Deploy to dev
-teamsapp deploy --env dev
+m365agents deploy --env dev
 
 # Deploy specific components only
-teamsapp deploy --env dev --component bot
-teamsapp deploy --env dev --component tab
+m365agents deploy --env dev --component bot
+m365agents deploy --env dev --component tab
 
 # Deploy without asking for confirmation
-teamsapp deploy --env dev --no-interactive
+m365agents deploy --env dev --no-interactive
 ```
 
 ---
 
-## Publishing to Teams App Catalog
+## Publishing
 
-### `teamsapp publish`
+### `m365agents publish`
 
 ```bash
-# Publish to your organization's Teams App Catalog
-teamsapp publish --env dev
-
-# Publish to a specific environment
-teamsapp publish --env production
-
-# Update an existing published app
-teamsapp update --env production --manifest-path ./appPackage/manifest.json
+# Publish to organization's Teams App Catalog
+m365agents publish --env dev
 
 # Package the app zip (without publishing)
-teamsapp package --env dev
+m365agents package --env dev
 # Output: ./appPackage/build/appPackage.dev.zip
 ```
 
-**After `teamsapp publish`, an admin must approve the app in the Teams Admin Center** at `https://admin.teams.microsoft.com/policies/manage-apps`.
+**After `m365agents publish`, an admin must approve the app in the Teams Admin Center.**
 
 ---
 
 ## Environment Management
 
-Teams Toolkit uses `.env.{envName}` files to manage per-environment configuration.
-
 ```bash
 # Create a new environment
-teamsapp env add staging
+m365agents env add staging
 
 # List environments
-teamsapp env list
-
-# Set an environment variable
-# (edit .env.staging directly or use the CLI)
-teamsapp env set --env staging MY_VAR=myvalue
+m365agents env list
 ```
 
 ### Environment file structure
@@ -225,10 +226,8 @@ teamsapp env set --env staging MY_VAR=myvalue
 # .env.dev — auto-generated; commit to source control (no secrets)
 TEAMS_APP_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 BOT_ID=yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy
+APP_TENANTID=zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz
 TAB_DOMAIN=myapp.azurewebsites.net
-TAB_ENDPOINT=https://myapp.azurewebsites.net
-AZURE_SUBSCRIPTION_ID=zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz
-AZURE_RESOURCE_GROUP_NAME=rg-myapp-dev
 
 # .env.dev.user — local overrides; NEVER commit (in .gitignore)
 SECRET_BOT_PASSWORD=<actual-secret>
@@ -239,32 +238,25 @@ SECRET_AAD_APP_CLIENT_SECRET=<actual-secret>
 
 ## Bicep Templates for Teams Resources
 
-Teams Toolkit generates Bicep templates in `./infra/`. Common resource patterns:
-
 ```bicep
-// infra/botservice.bicep
+// infra/botservice.bicep — Single-tenant bot registration
 @description('Bot Service name')
 param botServiceName string
-
-@description('Bot endpoint URL')
 param botEndpoint string
-
-@description('AAD App Registration Client ID')
 param botAadAppClientId string
+param appTenantId string
 
 resource botService 'Microsoft.BotService/botServices@2022-09-15' = {
   name: botServiceName
   location: 'global'
-  sku: {
-    name: 'F0'
-  }
+  sku: { name: 'F0' }
   kind: 'azurebot'
   properties: {
     displayName: botServiceName
     endpoint: botEndpoint
     msaAppId: botAadAppClientId
-    msaAppType: 'MultiTenant'
-    isStreamingSupported: false
+    msaAppType: 'SingleTenant'
+    msaAppTenantId: appTenantId
   }
 }
 
@@ -280,47 +272,6 @@ resource teamsChannel 'Microsoft.BotService/botServices/channels@2022-09-15' = {
     }
   }
 }
-
-output botServiceId string = botService.id
-```
-
-```bicep
-// infra/webapp.bicep — App Service for tab/bot hosting
-param webAppName string
-param location string = resourceGroup().location
-param sku string = 'B1'
-
-resource appServicePlan 'Microsoft.Web/serverfarms@2022-09-01' = {
-  name: '${webAppName}-plan'
-  location: location
-  sku: {
-    name: sku
-  }
-  kind: 'linux'
-  properties: {
-    reserved: true
-  }
-}
-
-resource webApp 'Microsoft.Web/sites@2022-09-01' = {
-  name: webAppName
-  location: location
-  kind: 'app,linux'
-  properties: {
-    serverFarmId: appServicePlan.id
-    siteConfig: {
-      linuxFxVersion: 'NODE|20-lts'
-      appSettings: [
-        { name: 'WEBSITE_RUN_FROM_PACKAGE', value: '1' }
-        { name: 'SCM_DO_BUILD_DURING_DEPLOYMENT', value: 'false' }
-      ]
-    }
-    httpsOnly: true
-  }
-}
-
-output webAppHostName string = webApp.properties.defaultHostName
-output webAppId string = webApp.id
 ```
 
 ---
@@ -330,7 +281,6 @@ output webAppId string = webApp.id
 ### GitHub Actions
 
 ```yaml
-# .github/workflows/teams-deploy.yml
 name: Deploy Teams App
 
 on:
@@ -338,31 +288,28 @@ on:
     branches: [main]
 
 permissions:
-  id-token: write  # For OIDC login to Azure
+  id-token: write
   contents: read
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     environment: production
-
     steps:
       - uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '20'
 
-      - name: Install Teams Toolkit CLI
-        run: npm install -g @microsoft/teamsapp-cli
+      - name: Install M365 Agents Toolkit CLI
+        run: npm install -g @microsoft/m365agentstoolkit-cli
 
       - name: Install dependencies
         run: npm ci
 
       - name: Login to M365
         run: |
-          teamsapp auth login m365 \
+          m365agents auth login m365 \
             --service-principal \
             --tenant-id ${{ secrets.M365_TENANT_ID }} \
             --client-id ${{ secrets.M365_CLIENT_ID }} \
@@ -375,73 +322,16 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Provision Azure resources
-        run: teamsapp provision --env production --no-interactive
+      - name: Provision and Deploy
+        run: |
+          m365agents provision --env production --no-interactive
+          m365agents deploy --env production --no-interactive
+          m365agents publish --env production --no-interactive
         env:
           TEAMS_APP_ID: ${{ vars.TEAMS_APP_ID }}
           BOT_ID: ${{ vars.BOT_ID }}
+          APP_TENANTID: ${{ secrets.APP_TENANTID }}
           SECRET_BOT_PASSWORD: ${{ secrets.BOT_PASSWORD }}
-          SECRET_AAD_APP_CLIENT_SECRET: ${{ secrets.AAD_CLIENT_SECRET }}
-
-      - name: Deploy app
-        run: teamsapp deploy --env production --no-interactive
-        env:
-          TEAMS_APP_ID: ${{ vars.TEAMS_APP_ID }}
-          BOT_ID: ${{ vars.BOT_ID }}
-
-      - name: Publish to Teams catalog
-        run: teamsapp publish --env production --no-interactive
-        env:
-          TEAMS_APP_ID: ${{ vars.TEAMS_APP_ID }}
-```
-
-### Azure Pipelines
-
-```yaml
-# azure-pipelines.yml
-trigger:
-  branches:
-    include: [main]
-
-pool:
-  vmImage: ubuntu-latest
-
-variables:
-  - group: teams-app-secrets
-
-steps:
-  - task: NodeTool@0
-    inputs:
-      versionSpec: '20.x'
-
-  - script: npm install -g @microsoft/teamsapp-cli
-    displayName: Install Teams Toolkit CLI
-
-  - script: npm ci
-    displayName: Install dependencies
-
-  - script: |
-      teamsapp auth login m365 \
-        --service-principal \
-        --tenant-id $(M365_TENANT_ID) \
-        --client-id $(M365_CLIENT_ID) \
-        --client-secret $(M365_CLIENT_SECRET)
-    displayName: Login to M365
-
-  - task: AzureCLI@2
-    displayName: Provision and Deploy
-    inputs:
-      azureSubscription: 'Teams App Service Connection'
-      scriptType: bash
-      scriptLocation: inlineScript
-      inlineScript: |
-        teamsapp provision --env production --no-interactive
-        teamsapp deploy --env production --no-interactive
-    env:
-      SECRET_BOT_PASSWORD: $(BOT_PASSWORD)
-      SECRET_AAD_APP_CLIENT_SECRET: $(AAD_CLIENT_SECRET)
-      TEAMS_APP_ID: $(TEAMS_APP_ID)
-      BOT_ID: $(BOT_ID)
 ```
 
 ---
@@ -450,30 +340,32 @@ steps:
 
 ```bash
 # Validate the app manifest
-teamsapp validate --manifest-path ./appPackage/manifest.json
+m365agents validate --manifest-path ./appPackage/manifest.json
 
 # Validate a packaged zip
-teamsapp validate --app-package-file ./appPackage/build/appPackage.dev.zip
-
-# Validate for Teams App Store submission
-teamsapp validate --env production --output-package-file ./submission.zip
+m365agents validate --app-package-file ./appPackage/build/appPackage.dev.zip
 ```
+
+### Known Validation Issues (v1.25)
+
+| Issue | Description | Workaround |
+|-------|-------------|-----------|
+| Regex validation bug | Schema validator rejects valid regex patterns (`.xll` regex error) | Skip `teamsApp/validateManifest` step; use manual packaging |
+| Dev Portal field persistence | Dev Portal may drop `nestedAppAuthInfo` and `agenticUserTemplates` on save | Always author manifests in codebase; upload zip directly |
+| `supportsChannelFeatures` dropped | Dev Portal may remove `supportsChannelFeatures` after editing | Edit manifest in code, not in portal |
 
 ---
 
-## Error Codes and Common Issues
+## Error Codes
 
 | Error | Meaning | Remediation |
 |-------|---------|-------------|
-| `ERR_M365_NOT_SIGNED_IN` | CLI not authenticated to M365 | Run `teamsapp auth login m365` |
-| `ERR_AZURE_NOT_SIGNED_IN` | CLI not authenticated to Azure | Run `teamsapp auth login azure` or use service principal |
-| `ERR_PROVISION_FAILED` | Bicep deployment failed | Check Azure resource quotas and Bicep template errors |
-| `ERR_DEPLOY_FAILED` | App deployment to Azure failed | Check App Service logs; verify deployment slot config |
-| Manifest validation error | Schema violation in `manifest.json` | Run `teamsapp validate --manifest-path`; check required fields |
-| `ERR_BOT_NOT_REGISTERED` | Bot ID not found in Bot Service | Re-run `teamsapp provision` to create bot registration |
-| OIDC auth error in CI | Federated identity not configured | Add GitHub/ADO as federated credential on Azure AD app registration |
-| `SECRET_*` vars not substituted | `.env.{env}.user` not present | Set secrets as environment variables in CI pipeline |
-| App not appearing in Teams | App not published or awaiting admin approval | Check Teams Admin Center > Manage apps |
+| `ERR_M365_NOT_SIGNED_IN` | CLI not authenticated | Run `m365agents auth login m365` |
+| `ERR_AZURE_NOT_SIGNED_IN` | Not authenticated to Azure | Run `m365agents auth login azure` |
+| `ERR_PROVISION_FAILED` | Bicep deployment failed | Check resource quotas and templates |
+| `ERR_DEPLOY_FAILED` | Deployment failed | Check App Service logs |
+| Manifest validation error | Schema violation | Run `m365agents validate`; check v1.25 bug list |
+| `ERR_BOT_NOT_REGISTERED` | Bot ID not found | Re-run `m365agents provision` |
 
 ---
 
@@ -481,10 +373,7 @@ teamsapp validate --env production --output-package-file ./submission.zip
 
 | Resource | Limit | Notes |
 |---|---|---|
-| Environments per project | No hard limit | Practical: dev, staging, production |
-| App package size (zip) | 1 MB | Manifest + icons only; not app code |
+| App package size (zip) | 1 MB | Manifest + icons only |
 | Manifest `validDomains` | 16 entries | Wildcards supported |
-| Teams App Store review | 5–7 business days | Submit early; resubmission resets queue |
-| Bot Service free tier | F0 (1,000 messages/month) | Upgrade to S1 for production |
-| App Service free tier (F1) | 60 CPU minutes/day | Use at least B1 for production bots |
-| Concurrent `teamsapp` runs | No CLI restriction | Azure resource locks may block concurrent provisions |
+| Bot Service free tier | F0 (1,000 messages/month) | Use S1 for production |
+| App Service free tier (F1) | 60 CPU minutes/day | Use at least B1 for bots |


### PR DESCRIPTION
Complete rewrite of the teams-app-dev plugin for the 2026 Teams development platform:

Manifest v1.25: Updated all examples to v1.25 schema with supportsChannelFeatures,
nestedAppAuthInfo (NAA), backgroundLoadConfiguration, agenticUserTemplates.
Documented known v1.25 bugs (regex validation, Dev Portal save issue).

Tooling: Teams Toolkit → M365 Agents Toolkit. CLI changed from
@microsoft/teamsapp-cli to @microsoft/m365agentstoolkit-cli. Config changed
from teamsapp.yml to m365agents.yml. Added Agents Playground for local testing.

Auth: Multi-tenant → Single-tenant enforced with APP_TENANTID. Added NAA
(Nested App Authentication) for pop-up-free iframe auth using MSAL.js.

Dialog namespace: dialog.url.open()/dialog.adaptiveCard.open() replaces
deprecated tasks namespace throughout.

Meeting apps: Full meeting app surfaces (side panel, stage, content bubble,
pre/post meeting tabs). Meeting-aware message extensions for agenda search
and action item creation. Content bubble notifications with alertInMeeting.

4 new commands: /teams-agent (Custom Engine Agents), /teams-dialog (dialog
orchestration), /teams-agent365 (Agent 365 blueprints with JS/Python/.NET),
/teams-migrate (TeamsFx → M365 Agents Toolkit migration guide).

Updated all 7 existing commands, 5 reference files, SKILL.md (complete
rewrite), reviewer agent, README, and plugin.json.

Additional 2026 platform alignment: Bot Framework SDK archived status,
TeamsJS v2.19+ enforcement, LUIS retirement, API-based message extensions
(no bot needed), Adaptive Card mobile v1.2 ceiling with compatibility
checklist, SDK decision matrix (Teams SDK vs Agents SDK vs Agent 365).

https://claude.ai/code/session_019tUi7YnUDbBCHTbpuUUjgJ