### PR TITLE
Standardize MCP and hooks configuration structure across plugins

### DIFF
--- a/agent-foundry/hooks/hooks.json
+++ b/agent-foundry/hooks/hooks.json
@@ -1,13 +1,15 @@
 {
-  "PostToolUse": [
-    {
-      "matcher": "Write|Edit",
-      "hooks": [
-        {
-          "type": "prompt",
-          "prompt": "Check whether the file just written or edited is a Claude Code agent definition file (a .md file located inside an agents/ directory, or a .md file whose YAML frontmatter contains a top-level 'description:' field that describes an agent role). If it is, invoke the Agent Evaluator agent to validate the file's frontmatter completeness, description clarity, tool scope, and system prompt quality. Report any issues found with severity (error/warning) and a short remediation suggestion. If the file is NOT an agent definition, do nothing."
-        }
-      ]
-    }
-  ]
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "Check whether the file just written or edited is a Claude Code agent definition file (a .md file located inside an agents/ directory, or a .md file whose YAML frontmatter contains a top-level 'description:' field that describes an agent role). If it is, invoke the Agent Evaluator agent to validate the file's frontmatter completeness, description clarity, tool scope, and system prompt quality. Report any issues found with severity (error/warning) and a short remediation suggestion. If the file is NOT an agent definition, do nothing."
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/artifacts/capability-graph.json
+++ b/artifacts/capability-graph.json
@@ -1,5 +1,7 @@
 {
-  "strictPluginScope": [],
+  "strictPluginScope": [
+    "agent-foundry"
+  ],
   "sourceFiles": {
     "claudeCatalog": "CLAUDE.md",
     "marketplace": ".claude-plugin/marketplace.json"

--- a/plugins/azure/.claude-plugin/plugin.json
+++ b/plugins/azure/.claude-plugin/plugin.json
@@ -15,5 +15,29 @@
     "microsoft",
     "azure",
     "infrastructure"
-  ]
+  ],
+  "mcpServers": {
+    "microsoft-azure-mcp": {
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/dist/index.js"],
+      "env": {
+        "MICROSOFT_CLIENT_ID": "${MICROSOFT_CLIENT_ID}",
+        "MICROSOFT_CLIENT_SECRET": "${MICROSOFT_CLIENT_SECRET}",
+        "MICROSOFT_TENANT_ID": "${MICROSOFT_TENANT_ID}",
+        "MICROSOFT_ACCESS_TOKEN": "${MICROSOFT_ACCESS_TOKEN}"
+      }
+    }
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/plugins/domain-business-name-finder/.mcp.json
+++ b/plugins/domain-business-name-finder/.mcp.json
@@ -1,24 +1,26 @@
 {
-  "firecrawl": {
-    "command": "npx",
-    "args": ["-y", "firecrawl-mcp"],
-    "env": {
-      "FIRECRAWL_API_KEY": "${FIRECRAWL_API_KEY}"
+  "mcpServers": {
+    "firecrawl": {
+      "command": "npx",
+      "args": ["-y", "firecrawl-mcp"],
+      "env": {
+        "FIRECRAWL_API_KEY": "${FIRECRAWL_API_KEY}"
+      }
+    },
+    "perplexity": {
+      "command": "npx",
+      "args": ["-yq", "@perplexity-ai/mcp-server"],
+      "env": {
+        "PERPLEXITY_API_KEY": "${PERPLEXITY_API_KEY}"
+      }
+    },
+    "whois": {
+      "command": "npx",
+      "args": ["-y", "@bharathvaj/whois-mcp@latest"]
+    },
+    "domain-search": {
+      "command": "npx",
+      "args": ["-y", "domain-search-mcp"]
     }
-  },
-  "perplexity": {
-    "command": "npx",
-    "args": ["-yq", "@perplexity-ai/mcp-server"],
-    "env": {
-      "PERPLEXITY_API_KEY": "${PERPLEXITY_API_KEY}"
-    }
-  },
-  "whois": {
-    "command": "npx",
-    "args": ["-y", "@bharathvaj/whois-mcp@latest"]
-  },
-  "domain-search": {
-    "command": "npx",
-    "args": ["-y", "domain-search-mcp"]
   }
 }

--- a/plugins/excel/.claude-plugin/plugin.json
+++ b/plugins/excel/.claude-plugin/plugin.json
@@ -15,5 +15,29 @@
     "microsoft",
     "excel",
     "data"
-  ]
+  ],
+  "mcpServers": {
+    "microsoft-excel-mcp": {
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/dist/index.js"],
+      "env": {
+        "MICROSOFT_CLIENT_ID": "${MICROSOFT_CLIENT_ID}",
+        "MICROSOFT_CLIENT_SECRET": "${MICROSOFT_CLIENT_SECRET}",
+        "MICROSOFT_TENANT_ID": "${MICROSOFT_TENANT_ID}",
+        "MICROSOFT_ACCESS_TOKEN": "${MICROSOFT_ACCESS_TOKEN}"
+      }
+    }
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/plugins/outlook/.claude-plugin/plugin.json
+++ b/plugins/outlook/.claude-plugin/plugin.json
@@ -15,5 +15,29 @@
     "microsoft",
     "outlook",
     "email"
-  ]
+  ],
+  "mcpServers": {
+    "microsoft-outlook-mcp": {
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/dist/index.js"],
+      "env": {
+        "MICROSOFT_CLIENT_ID": "${MICROSOFT_CLIENT_ID}",
+        "MICROSOFT_CLIENT_SECRET": "${MICROSOFT_CLIENT_SECRET}",
+        "MICROSOFT_TENANT_ID": "${MICROSOFT_TENANT_ID}",
+        "MICROSOFT_ACCESS_TOKEN": "${MICROSOFT_ACCESS_TOKEN}"
+      }
+    }
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/plugins/sharepoint/.claude-plugin/plugin.json
+++ b/plugins/sharepoint/.claude-plugin/plugin.json
@@ -15,5 +15,29 @@
     "microsoft",
     "sharepoint",
     "documents"
-  ]
+  ],
+  "mcpServers": {
+    "microsoft-sharepoint-mcp": {
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/dist/index.js"],
+      "env": {
+        "MICROSOFT_CLIENT_ID": "${MICROSOFT_CLIENT_ID}",
+        "MICROSOFT_CLIENT_SECRET": "${MICROSOFT_CLIENT_SECRET}",
+        "MICROSOFT_TENANT_ID": "${MICROSOFT_TENANT_ID}",
+        "MICROSOFT_ACCESS_TOKEN": "${MICROSOFT_ACCESS_TOKEN}"
+      }
+    }
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/plugins/teams/.claude-plugin/plugin.json
+++ b/plugins/teams/.claude-plugin/plugin.json
@@ -15,5 +15,29 @@
     "microsoft",
     "teams",
     "collaboration"
-  ]
+  ],
+  "mcpServers": {
+    "microsoft-teams-mcp": {
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/dist/index.js"],
+      "env": {
+        "MICROSOFT_CLIENT_ID": "${MICROSOFT_CLIENT_ID}",
+        "MICROSOFT_CLIENT_SECRET": "${MICROSOFT_CLIENT_SECRET}",
+        "MICROSOFT_TENANT_ID": "${MICROSOFT_TENANT_ID}",
+        "MICROSOFT_ACCESS_TOKEN": "${MICROSOFT_ACCESS_TOKEN}"
+      }
+    }
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/scripts/validate-plugins.mjs
+++ b/scripts/validate-plugins.mjs
@@ -50,6 +50,48 @@ for (const pluginEntry of marketplace.plugins ?? []) {
   const isMcpPlugin = hasPackageJson || hasMcpConfig || declaresMcpServers;
   const isInfrastructurePlugin = isMcpPlugin || declaresLspServers || declaresHooks;
 
+  // .mcp.json must wrap servers under "mcpServers" per the Claude Code plugin spec.
+  if (hasMcpConfig) {
+    try {
+      const mcp = JSON.parse(fs.readFileSync(path.join(pluginDir, '.mcp.json'), 'utf8'));
+      if (!mcp || typeof mcp.mcpServers !== 'object' || mcp.mcpServers === null) {
+        fail(`.mcp.json in ${toRepoPath(pluginDir)} must wrap servers under top-level "mcpServers" key`);
+      }
+    } catch (err) {
+      fail(`Could not parse .mcp.json in ${toRepoPath(pluginDir)}: ${err.message}`);
+    }
+  }
+
+  // hooks/hooks.json (or any hooks file referenced by manifest.hooks as a string)
+  // must wrap event handlers under a top-level "hooks" key.
+  const hookFilePaths = [];
+  const defaultHooksFile = path.join(pluginDir, 'hooks', 'hooks.json');
+  if (fs.existsSync(defaultHooksFile) && fs.statSync(defaultHooksFile).isFile()) {
+    hookFilePaths.push(defaultHooksFile);
+  }
+  if (typeof manifest.hooks === 'string') {
+    const hp = path.join(pluginDir, manifest.hooks);
+    if (fs.existsSync(hp) && fs.statSync(hp).isFile() && !hookFilePaths.includes(hp)) {
+      hookFilePaths.push(hp);
+    }
+  }
+  for (const hp of hookFilePaths) {
+    try {
+      const h = JSON.parse(fs.readFileSync(hp, 'utf8'));
+      if (!h || typeof h.hooks !== 'object' || h.hooks === null) {
+        fail(`Hook file ${toRepoPath(hp)} must wrap event handlers under top-level "hooks" key`);
+      }
+    } catch (err) {
+      fail(`Could not parse hook file ${toRepoPath(hp)}: ${err.message}`);
+    }
+  }
+
+  // Bundled MCP plugins (package.json + dist/) need a runnable mcpServers
+  // declaration in the manifest, otherwise Claude Code never starts the server.
+  if (hasPackageJson && !declaresMcpServers && !hasMcpConfig) {
+    fail(`Plugin ${pluginEntry.name} ships an MCP bundle (package.json) but does not declare mcpServers in plugin.json or a .mcp.json file`);
+  }
+
   if (!isInfrastructurePlugin) {
     if (!fs.existsSync(skillsDir) || !hasSkillFile(skillsDir)) {
       fail(`Missing required skills/*/SKILL.md in ${toRepoPath(pluginDir)} for plugin ${pluginEntry.name}`);


### PR DESCRIPTION
## Summary
This PR standardizes the configuration structure for MCP servers and hooks across all plugins to comply with the Claude Code plugin specification. It wraps server and hook definitions under top-level `mcpServers` and `hooks` keys respectively, and adds validation to enforce this structure.

## Key Changes

- **Domain Business Name Finder plugin**: Wrapped all MCP server definitions (firecrawl, perplexity, whois, domain-search) under a top-level `mcpServers` key in `.mcp.json`

- **Microsoft plugins** (Azure, Excel, Outlook, SharePoint, Teams): Added `mcpServers` declarations to `plugin.json` manifest files with proper environment variable configuration for Microsoft authentication, and added `hooks` configuration for SessionStart events

- **Validation script enhancement** (`scripts/validate-plugins.mjs`):
  - Added validation to ensure `.mcp.json` files wrap servers under `mcpServers` key
  - Added validation for hooks files to wrap event handlers under `hooks` key
  - Added check to ensure bundled MCP plugins (with `package.json`) declare `mcpServers` in manifest or `.mcp.json`
  - Improved error messages with file paths for easier debugging

- **Agent Foundry hooks**: Wrapped hook definitions under top-level `hooks` key in `hooks.json`

- **Capability graph**: Added "agent-foundry" to `strictPluginScope` array

## Implementation Details

All configuration files now follow the standardized structure required by the Claude Code plugin specification:
- MCP server configurations use `mcpServers` as the top-level key
- Hook configurations use `hooks` as the top-level key
- Environment variables are properly scoped within server/hook definitions
- The validation script enforces these requirements for all plugins in the marketplace

https://claude.ai/code/session_01An7g6Tphhi16L2wZF3NEpF